### PR TITLE
Added an attribute to use the main_offline_light image when using the li...

### DIFF
--- a/subsonic-android/res/layout/main_buttons.xml
+++ b/subsonic-android/res/layout/main_buttons.xml
@@ -46,7 +46,7 @@
 		android:id="@+id/main_offline"
 		android:text="@string/main.offline"
 		android:drawablePadding="12dip"
-		android:drawableLeft="@drawable/main_offline"
+		android:drawableLeft="?attr/offline_icon"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceMedium"

--- a/subsonic-android/res/values/attrs.xml
+++ b/subsonic-android/res/values/attrs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="offline_icon" format="reference"/>
+</resources>

--- a/subsonic-android/res/values/themes.xml
+++ b/subsonic-android/res/values/themes.xml
@@ -5,17 +5,20 @@
 		<item name="android:actionBarStyle">@style/Widget.DSub.ActionBarStyle.Light</item>
 		<item name="android:textColorSecondary">@color/cyan</item>
 		<item name="android:windowBackground">@color/lightBackground</item>
+		<item name="offline_icon">@drawable/main_offline_light</item>
 	</style>
 	<style name="Theme.DSub.Dark" parent="Theme.Sherlock.ForceOverflow">
 		<item name="actionBarStyle">@style/Widget.DSub.ActionBarStyle.Dark</item>
 		<item name="android:actionBarStyle">@style/Widget.DSub.ActionBarStyle.Dark</item>
 		<item name="android:textColorSecondary">@color/cyan</item>
+		<item name="offline_icon">@drawable/main_offline</item>
 	</style>
 	<style name="Theme.DSub.Holo" parent="Theme.Sherlock.ForceOverflow">
 		<item name="actionBarStyle">@style/Widget.DSub.ActionBarStyle.Holo</item>
 		<item name="android:actionBarStyle">@style/Widget.DSub.ActionBarStyle.Holo</item>
 		<item name="android:textColorSecondary">@color/cyan</item>
 		<item name="android:windowBackground">@drawable/background</item>
+		<item name="offline_icon">@drawable/main_offline</item>
 	</style>
 	
 	<style name="Theme.DSub.Light.Fullscreen" parent="Theme.DSub.Light">


### PR DESCRIPTION
...ght sytle.

Greetings. I use Subsonic on a daily basis and like your DSub app better than the official one.  Keep up the good work!  I've been following the progress on github.  I found this solution to use the _light icon for the offline button.  Hope it helps or at least gives an idea of how you want to implement it. 

![2012-12-10 21 38 02](https://f.cloud.github.com/assets/1691142/5025/e343524c-433b-11e2-89ec-8a14120ad8c7.png)
