### PR TITLE
Fix NPE in download of file when song has no transcode suffix

### DIFF
--- a/src/github/daneren2005/dsub/service/DownloadFile.java
+++ b/src/github/daneren2005/dsub/service/DownloadFile.java
@@ -95,13 +95,14 @@ public class DownloadFile {
     }
 	private int getActualBitrate() {
 		int br = song.isVideo() ? Util.getMaxVideoBitrate(context) : Util.getMaxBitrate(context);
-		if(br == 0 && "mp3".equals(song.getTranscodedSuffix().toLowerCase())) {
-			if(song.getBitRate() != null) {
-				br = Math.min(320, song.getBitRate());
-			} else {
-				br = 320;
-			}
-		}
+        if (br == 0 && song.getTranscodedSuffix() != null &&
+                "mp3".equals(song.getTranscodedSuffix().toLowerCase()) &&
+                song.getBitRate() != null) {
+            br = Math.min(320, song.getBitRate());
+        } else {
+            br = 320;
+        }
+
 		return br;
 	}
 	


### PR DESCRIPTION
If a song has no transcoded suffix, the song will fail to download because the `getActualBitrate` method causes a NPE. This is now fixed.
