### PR TITLE
Added optional "local network SSID" to server settings

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19"/>
 
     <supports-screens android:anyDensity="true" android:xlargeScreens="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application android:label="@string/common.appname"
     	android:backupAgent="github.daneren2005.dsub.util.SettingsBackupAgent"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -244,7 +244,8 @@
     <string name="settings.server_unused">Unused</string>
     <string name="settings.server_name">Name</string>
     <string name="settings.server_address">Server address</string>
-	<string name="settings.server_internal_address">Internal network address</string>
+	<string name="settings.server_local_network_ssid" >Local network</string>
+	<string name="settings.server_internal_address">Local network address</string>
     <string name="settings.server_username">Username</string>
     <string name="settings.server_password">Password</string>
 	<string name="settings.server_open_browser">Open in browser</string>

--- a/src/github/daneren2005/dsub/activity/SettingsActivity.java
+++ b/src/github/daneren2005/dsub/activity/SettingsActivity.java
@@ -322,6 +322,10 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 
 		serverUrlPreference.setSummary(serverUrlPreference.getText());
 		screen.setSummary(serverUrlPreference.getText());
+		
+		final EditTextPreference serverLocalNetworkSSIDPreference = new EditTextPreference(this);
+		serverLocalNetworkSSIDPreference.setKey(Constants.PREFERENCES_KEY_SERVER_LOCAL_NETWORK_SSID + instance);
+		serverLocalNetworkSSIDPreference.setTitle(R.string.settings_server_local_network_ssid);
 
 		final EditTextPreference serverInternalUrlPreference = new EditTextPreference(this);
 		serverInternalUrlPreference.setKey(Constants.PREFERENCES_KEY_SERVER_INTERNAL_URL + instance);
@@ -402,6 +406,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 
 		screen.addPreference(serverNamePreference);
 		screen.addPreference(serverUrlPreference);
+		screen.addPreference(serverLocalNetworkSSIDPreference);
 		screen.addPreference(serverInternalUrlPreference);
 		screen.addPreference(serverUsernamePreference);
 		screen.addPreference(serverPasswordPreference);
@@ -533,6 +538,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
     private class ServerSettings {
         private EditTextPreference serverName;
         private EditTextPreference serverUrl;
+        private EditTextPreference serverLocalNetworkSSID;
 		private EditTextPreference serverInternalUrl;
         private EditTextPreference username;
         private PreferenceScreen screen;
@@ -542,6 +548,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
             screen = (PreferenceScreen) findPreference("server" + instance);
             serverName = (EditTextPreference) findPreference(Constants.PREFERENCES_KEY_SERVER_NAME + instance);
             serverUrl = (EditTextPreference) findPreference(Constants.PREFERENCES_KEY_SERVER_URL + instance);
+            serverLocalNetworkSSID = (EditTextPreference) findPreference(Constants.PREFERENCES_KEY_SERVER_LOCAL_NETWORK_SSID + instance);
 			serverInternalUrl = (EditTextPreference) findPreference(Constants.PREFERENCES_KEY_SERVER_INTERNAL_URL + instance);
             username = (EditTextPreference) findPreference(Constants.PREFERENCES_KEY_USERNAME + instance);
 
@@ -594,6 +601,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
         public void update() {
             serverName.setSummary(serverName.getText());
             serverUrl.setSummary(serverUrl.getText());
+            serverLocalNetworkSSID.setSummary(serverLocalNetworkSSID.getText());
 			serverInternalUrl.setSummary(serverInternalUrl.getText());
             username.setSummary(username.getText());
             screen.setSummary(serverUrl.getText());

--- a/src/github/daneren2005/dsub/util/Constants.java
+++ b/src/github/daneren2005/dsub/util/Constants.java
@@ -77,6 +77,7 @@ public final class Constants {
     public static final String PREFERENCES_KEY_SERVER_NAME = "serverName";
     public static final String PREFERENCES_KEY_SERVER_URL = "serverUrl";
 	public static final String PREFERENCES_KEY_SERVER_INTERNAL_URL = "serverInternalUrl";
+	public static final String PREFERENCES_KEY_SERVER_LOCAL_NETWORK_SSID = "serverLocalNetworkSSID";
 	public static final String PREFERENCES_KEY_SERVER_VERSION = "serverVersion";
 	public static final String PREFERENCES_KEY_TEST_CONNECTION = "serverTestConnection";
 	public static final String PREFERENCES_KEY_OPEN_BROWSER = "openBrowser";

--- a/src/github/daneren2005/dsub/util/Util.java
+++ b/src/github/daneren2005/dsub/util/Util.java
@@ -38,6 +38,7 @@ import android.media.AudioManager;
 import android.media.AudioManager.OnAudioFocusChangeListener;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Environment;
@@ -65,6 +66,7 @@ import github.daneren2005.dsub.receiver.MediaButtonIntentReceiver;
 import github.daneren2005.dsub.service.DownloadFile;
 import github.daneren2005.dsub.service.DownloadService;
 import github.daneren2005.dsub.service.DownloadServiceImpl;
+
 import org.apache.http.HttpEntity;
 
 import java.io.ByteArrayOutputStream;
@@ -358,7 +360,9 @@ public final class Util {
 		StringBuilder builder = new StringBuilder();
 
 		String serverUrl = prefs.getString(Constants.PREFERENCES_KEY_SERVER_URL + instance, null);
-		if(allowAltAddress && Util.isWifiConnected(context)) {
+		if(allowAltAddress && 
+				(prefs.getString(Constants.PREFERENCES_KEY_SERVER_LOCAL_NETWORK_SSID + instance, "").equals("") && Util.isWifiConnected(context))
+				|| prefs.getString(Constants.PREFERENCES_KEY_SERVER_LOCAL_NETWORK_SSID + instance, "").equals(Util.getSSID(context))) {
 			String internalUrl = prefs.getString(Constants.PREFERENCES_KEY_SERVER_INTERNAL_URL + instance, null);
 			if(internalUrl != null && !"".equals(internalUrl) && !"http://".equals(internalUrl)) {
 				serverUrl = internalUrl;
@@ -846,6 +850,16 @@ public final class Util {
 		NetworkInfo networkInfo = manager.getActiveNetworkInfo();
 		boolean connected = networkInfo != null && networkInfo.isConnected();
 		return connected && (networkInfo.getType() == ConnectivityManager.TYPE_WIFI);
+	}
+	public static String getSSID(Context context) {
+		if (isWifiConnected(context)) {
+			WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+			if (wifiManager.getConnectionInfo() != null && wifiManager.getConnectionInfo().getSSID() != null) {
+				return wifiManager.getConnectionInfo().getSSID().replace("\"", "");
+			}
+			return null;
+		}
+		return null;
 	}
 
     public static boolean isExternalStoragePresent() {


### PR DESCRIPTION
Added the option to specify a local network SSID within server settings.

If given, DSub will only use the "internal" network address when connected to a wifi network with that SSID, otherwise it will use the internal address when connected to any wifi network as before.

Useful for people who regularly connect to multiple wifi networks.
