### PR TITLE
Darkens the actionbar in dark/night themes

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,10 @@
 	<color name="lightPrimaryDark">#1e88e5</color>
 	<color name="lightAccent">#448aff</color>
 
+	<color name="darkPrimary">#1664a2</color>
+	<color name="darkPrimaryDark">#0f4472</color>
+	<color name="darkAccent">#2d5caa</color>
+
 	<color name="holoPrimary">#009688</color>
 	<color name="holoPrimaryDark">#00897b</color>
 	<color name="holoAccent">#64ffda</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -128,10 +128,10 @@
 		<item name="drawerDownloading">@drawable/ic_menu_download_dark</item>
 		<item name="drawerSettings">@drawable/ic_menu_settings_dark</item>
 		<item name="drawerArrowStyle">@style/DSub.DrawerArrow</item>
-		<item name="colorPrimary">@color/lightPrimary</item>
-		<item name="colorPrimaryDark">@color/lightPrimaryDark</item>
-		<item name="colorAccent">@color/lightAccent</item>
-		<item name="actionbarBackgroundColor">@color/lightPrimary</item>
+		<item name="colorPrimary">@color/darkPrimary</item>
+		<item name="colorPrimaryDark">@color/darkPrimaryDark</item>
+		<item name="colorAccent">@color/darkAccent</item>
+		<item name="actionbarBackgroundColor">@color/darkPrimaryDark</item>
 		<item name="actionbarTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title</item>
 		<item name="actionbarSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle</item>
 		<item name="actionbarPopupStyle">@style/ThemeOverlay.AppCompat.Dark</item>


### PR DESCRIPTION
I darkened the colors to 66% of the light colors, except for darkPrimaryDark which is 50%.
![old](https://cloud.githubusercontent.com/assets/1592375/21753268/bccfc98e-d59e-11e6-9f1d-52ad4b7e87f4.png)![new2](https://cloud.githubusercontent.com/assets/1592375/21753298/3076e28c-d59f-11e6-9976-2f8aa2b4d389.png)

Because the Black theme inherits from Dark, this change also applies in that theme. Holo has its own settings.
