### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Basic Instructions
+## Basic Instructions
 Grab dependent libraries
 ```
 git submodule init
@@ -12,19 +12,19 @@ android update project --path ./
 
 Add both projects and all .jar's in the libs folder
 
-##SDK Project Dependencies
+## SDK Project Dependencies
 Under sdk -> extras:<br>
 android -> support -> v7 -> appcompat<br>
 android -> support -> v7 -> mediarouter<br>
 google -> google_play_services -> libproject -> google-play-services_lib
 
-##SDK Library Dependencies
+## SDK Library Dependencies
 android -> support -> v4 -> android-support-v4.jar<br>
 android -> support -> v7 -> appcompat -> libs android-support-v7-appcompat.jar<br>
 android -> support -> v7 -> mediarouter -> libs -> android-support-v7-mediarouter.jar<br>
 google -> google_play_services -> libproject -> google-play-services_lib -> lib -> google-play-services.jar
 
-##Updating Icons
+## Updating Icons
 Media Icons are double standard size.  On https://romannurik.github.io/AndroidAssetStudio/icons-actionbar.html you can manually change this via the following js commands:
 ```
 PARAM_RESOURCES.iconSize = {w: 64, h: 64}


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
