### PR TITLE
Change SeekBarPreference value to center alignment

### DIFF
--- a/app/src/main/res/layout/seekbar_preference.xml
+++ b/app/src/main/res/layout/seekbar_preference.xml
@@ -9,7 +9,7 @@
 		android:padding="5dip"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:gravity="right"
+		android:gravity="center"
 		android:textColor="?android:textColorPrimary"/>
 	<SeekBar
 		android:id="@+id/seek_bar"


### PR DESCRIPTION
Changing this to center alignment will bring it in line with similar dialog boxes, i.e. Google Keyboard:

![image](https://user-images.githubusercontent.com/8548596/26995134-111976f4-4d39-11e7-9755-c403c80edabb.png)
<img src="https://user-images.githubusercontent.com/8548596/26995038-99b9ec9c-4d38-11e7-8fe0-69ddc26077fa.png" width="338" height="150" />