### PR TITLE
Add Rewind/Fast Forward Jump Interval Preferences

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
@@ -1175,10 +1175,10 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 							downloadService.previous();
 							break;
 						case ACTION_FORWARD:
-							downloadService.seekTo(downloadService.getPlayerPosition() + DownloadService.FAST_FORWARD);
+							downloadService.fastForward();
 							break;
 						case ACTION_REWIND:
-							downloadService.seekTo(downloadService.getPlayerPosition() - DownloadService.REWIND);
+							downloadService.rewind();
 							break;
 					}
 					return null;

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -107,8 +107,6 @@ public class DownloadService extends Service {
 	public static final String CMD_NEXT = "github.daneren2005.dsub.CMD_NEXT";
 	public static final String CANCEL_DOWNLOADS = "github.daneren2005.dsub.CANCEL_DOWNLOADS";
 	public static final String START_PLAY = "github.daneren2005.dsub.START_PLAYING";
-	public static final int FAST_FORWARD = 30000;
-	public static final int REWIND = 10000;
 	private static final long DEFAULT_DELAY_UPDATE_PROGRESS = 1000L;
 	private static final double DELETE_CUTOFF = 0.84;
 	private static final int REQUIRED_ALBUM_MATCHES = 4;
@@ -1174,10 +1172,10 @@ public class DownloadService extends Service {
 		}
 	}
 	public synchronized int rewind() {
-		return seekToWrapper(-REWIND);
+		return seekToWrapper(Integer.parseInt(Util.getPreferences(this).getString(Constants.PREFERENCES_KEY_REWIND_INTERVAL, "10"))*-1000);
 	}
 	public synchronized int fastForward() {
-		return seekToWrapper(FAST_FORWARD);
+		return seekToWrapper(Integer.parseInt(Util.getPreferences(this).getString(Constants.PREFERENCES_KEY_FASTFORWARD_INTERVAL, "30"))*1000);
 	}
 	protected int seekToWrapper(int difference) {
 		int msPlayed = Math.max(0, getPlayerPosition());

--- a/app/src/main/java/github/daneren2005/dsub/util/Constants.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Constants.java
@@ -179,7 +179,9 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_PLAYBACK_SPEED = "playbackSpeed";
 	public static final String PREFERENCES_KEY_SONG_PLAYBACK_SPEED = "songPlaybackSpeed";
 	public static final String PREFERENCES_KEY_DLNA_CASTING_ENABLED = "dlnaCastingEnabled";
-	
+	public static final String PREFERENCES_KEY_REWIND_INTERVAL = "rewindInterval";
+	public static final String PREFERENCES_KEY_FASTFORWARD_INTERVAL = "fastforwardInterval";
+
 	public static final String OFFLINE_SCROBBLE_COUNT = "scrobbleCount";
 	public static final String OFFLINE_SCROBBLE_ID = "scrobbleID";
 	public static final String OFFLINE_SCROBBLE_SEARCH = "scrobbleTitle";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,6 +491,8 @@
 	<string name="settings.casting_cache_summary">Cache currently playing songs while casting</string>
 	<string name="settings.casting.dlna_casting_enabled">DLNA Enabled</string>
 	<string name="settings.casting.dlna_casting_enabled.summary">If you are having battery drain problems on Android 7.0 try turning this off</string>
+    <string name="settings.rewind_interval">Rewind Interval</string>
+    <string name="settings.fastforward_interval">Fast Forward Interval</string>
 
 	<string name="shuffle.title">Shuffle By</string>
 	<string name="shuffle.startYear">Start Year:</string>

--- a/app/src/main/res/xml/settings_playback.xml
+++ b/app/src/main/res/xml/settings_playback.xml
@@ -52,6 +52,20 @@
 			android:defaultValue="all"
 			android:entryValues="@array/songPressActionValues"
 			android:entries="@array/songPressActionNames"/>
+
+        <github.daneren2005.dsub.view.SeekBarPreference
+            android:title="@string/settings.rewind_interval"
+            android:key="rewindInterval"
+            android:defaultValue="10"
+            android:dialogLayout="@layout/seekbar_preference"
+            myns:max="60"/>
+
+        <github.daneren2005.dsub.view.SeekBarPreference
+            android:title="@string/settings.fastforward_interval"
+            android:key="fastforwardInterval"
+            android:defaultValue="30"
+            android:dialogLayout="@layout/seekbar_preference"
+            myns:max="60"/>
 	</PreferenceCategory>
 
 	<PreferenceCategory


### PR DESCRIPTION
Adds preferences under Settings->Playback to allow users to set how far they want to rewind or fast forward.  Defaults are still set to 10s and 30s respectively, which is currently hard-coded.

For the record, I'm not really pleased with using Integer.parseInt(Util.getPreferences(this).getString(...)) instead of Util.getPreferences(this).getInt(...).  It's not really an elegant solution to cast it in this way, but it works.