### PR TITLE
Bugfix: Previous and next button behavior while long song is paused

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/activity/SubsonicFragmentActivity.java
+++ b/app/src/main/java/github/daneren2005/dsub/activity/SubsonicFragmentActivity.java
@@ -920,7 +920,7 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 	}
 
 	@Override
-	public void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex) {
+	public void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward) {
 		this.currentPlaying = currentPlaying;
 
 		MusicDirectory.Entry song = null;
@@ -950,13 +950,18 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 			getImageLoader().loadImage(coverArtView, song, false, height, false);
 		}
 
-		if(getDownloadService().isCurrentPlayingSingle()) {
+		updateMediaButtons(shouldFastForward);
+	}
+
+	private void updateMediaButtons(boolean shouldFastForward) {
+		DownloadService downloadService = getDownloadService();
+		if(downloadService.isCurrentPlayingSingle()) {
 			previousButton.setVisibility(View.GONE);
 			nextButton.setVisibility(View.GONE);
 			rewindButton.setVisibility(View.GONE);
 			fastforwardButton.setVisibility(View.GONE);
 		} else {
-			if (currentPlaying != null && currentPlaying.getSong() != null && (currentPlaying.getSong().isPodcast() || currentPlaying.getSong().isAudioBook())) {
+			if (shouldFastForward) {
 				previousButton.setVisibility(View.GONE);
 				nextButton.setVisibility(View.GONE);
 
@@ -973,9 +978,11 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 	}
 
 	@Override
-	public void onSongsChanged(List<DownloadFile> songs, DownloadFile currentPlaying, int currentPlayingIndex) {
+	public void onSongsChanged(List<DownloadFile> songs, DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward) {
 		if(this.currentPlaying != currentPlaying || this.currentPlaying == null) {
-			onSongChanged(currentPlaying, currentPlayingIndex);
+			onSongChanged(currentPlaying, currentPlayingIndex, shouldFastForward);
+		} else {
+			updateMediaButtons(shouldFastForward);
 		}
 	}
 

--- a/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
@@ -1222,17 +1222,24 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 	}
 
 	@Override
-	public void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex) {
+	public void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward) {
 		this.currentPlaying = currentPlaying;
 		setupSubtitle(currentPlayingIndex);
 
-		if(getDownloadService().isCurrentPlayingSingle()) {
+		updateMediaButton(shouldFastForward);
+		updateTitle();
+		setPlaybackSpeed();
+	}
+
+	private void updateMediaButton(boolean shouldFastForward) {
+		DownloadService downloadService = getDownloadService();
+		if(downloadService.isCurrentPlayingSingle()) {
 			previousButton.setVisibility(View.GONE);
 			nextButton.setVisibility(View.GONE);
 			rewindButton.setVisibility(View.GONE);
 			fastforwardButton.setVisibility(View.GONE);
 		} else {
-			if (currentPlaying != null && !currentPlaying.isSong()) {
+			if (downloadService.shouldFastForward()) {
 				previousButton.setVisibility(View.GONE);
 				nextButton.setVisibility(View.GONE);
 
@@ -1246,8 +1253,6 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 				fastforwardButton.setVisibility(View.GONE);
 			}
 		}
-		updateTitle();
-		setPlaybackSpeed();
 	}
 
 	private void setupSubtitle(int currentPlayingIndex) {
@@ -1274,7 +1279,7 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 	}
 
 	@Override
-	public void onSongsChanged(List<DownloadFile> songs, DownloadFile currentPlaying, int currentPlayingIndex) {
+	public void onSongsChanged(List<DownloadFile> songs, DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward) {
 		currentPlayingSize = songs.size();
 
 		DownloadService downloadService = getDownloadService();
@@ -1303,9 +1308,10 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		}
 
 		if(this.currentPlaying != currentPlaying) {
-			onSongChanged(currentPlaying, currentPlayingIndex);
+			onSongChanged(currentPlaying, currentPlayingIndex, shouldFastForward);
 			onMetadataUpdate(currentPlaying != null ? currentPlaying.getSong() : null, DownloadService.METADATA_UPDATED_ALL);
 		} else {
+			updateMediaButton(shouldFastForward);
 			setupSubtitle(currentPlayingIndex);
 		}
 

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -1209,6 +1209,14 @@ public class DownloadService extends Service {
 			return;
 		}
 
+		// If only one song, just skip within song
+		if(shouldFastForward()) {
+			rewind();
+			return;
+		} else if(playerState == PREPARING || playerState == PREPARED) {
+			return;
+		}
+
 		// Restart song if played more than five seconds.
 		if (getPlayerPosition() > 5000 || (index == 0 && getRepeatMode() != RepeatMode.ALL)) {
 			seekTo(0);
@@ -1228,7 +1236,11 @@ public class DownloadService extends Service {
 		next(forceCutoff, false);
 	}
 	public synchronized void next(boolean forceCutoff, boolean forceStart) {
-		if(playerState == PREPARING || playerState == PREPARED) {
+		// If only one song, just skip within song
+		if(shouldFastForward()) {
+			fastForward();
+			return;
+		} else if(playerState == PREPARING || playerState == PREPARED) {
 			return;
 		}
 

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -1027,6 +1027,10 @@ public class DownloadService extends Service {
 		}
 	}
 
+	public synchronized boolean shouldFastForward() {
+		return size() == 1 || (currentPlaying != null && !currentPlaying.isSong());
+	}
+
 	public synchronized List<DownloadFile> getDownloads() {
 		List<DownloadFile> temp = new ArrayList<DownloadFile>();
 		temp.addAll(downloadList);
@@ -1196,17 +1200,14 @@ public class DownloadService extends Service {
 	}
 
 	public synchronized void previous() {
+		if(playerState == PREPARING || playerState == PREPARED) {
+			return;
+		}
+
 		int index = getCurrentPlayingIndex();
 		if (index == -1) {
 			return;
 		}
-
-		// If only one song, just skip within song
-		if(size() == 1) {
-			rewind();
-			return;
-		}
-
 
 		// Restart song if played more than five seconds.
 		if (getPlayerPosition() > 5000 || (index == 0 && getRepeatMode() != RepeatMode.ALL)) {
@@ -1227,11 +1228,7 @@ public class DownloadService extends Service {
 		next(forceCutoff, false);
 	}
 	public synchronized void next(boolean forceCutoff, boolean forceStart) {
-		// If only one song, just skip within song
-		if(size() == 1) {
-			fastForward();
-			return;
-		} else if(playerState == PREPARING || playerState == PREPARED) {
+		if(playerState == PREPARING || playerState == PREPARED) {
 			return;
 		}
 
@@ -2819,12 +2816,13 @@ public class DownloadService extends Service {
 	private void onSongChanged() {
 		final long atRevision = revision;
 		synchronized(onSongChangedListeners) {
+			final boolean shouldFastForward = shouldFastForward();
 			for (final OnSongChangedListener listener : onSongChangedListeners) {
 				handler.post(new Runnable() {
 					@Override
 					public void run() {
 						if (revision == atRevision && instance != null) {
-							listener.onSongChanged(currentPlaying, currentPlayingIndex);
+							listener.onSongChanged(currentPlaying, currentPlayingIndex, shouldFastForward);
 
 							MusicDirectory.Entry entry = currentPlaying != null ? currentPlaying.getSong() : null;
 							listener.onMetadataUpdate(entry, METADATA_UPDATED_ALL);
@@ -2846,12 +2844,13 @@ public class DownloadService extends Service {
 	private void onSongsChanged() {
 		final long atRevision = revision;
 		synchronized(onSongChangedListeners) {
+			final boolean shouldFastForward = shouldFastForward();
 			for (final OnSongChangedListener listener : onSongChangedListeners) {
 				handler.post(new Runnable() {
 					@Override
 					public void run() {
 						if (revision == atRevision && instance != null) {
-							listener.onSongsChanged(downloadList, currentPlaying, currentPlayingIndex);
+							listener.onSongsChanged(downloadList, currentPlaying, currentPlayingIndex, shouldFastForward);
 						}
 					}
 				});
@@ -3051,8 +3050,8 @@ public class DownloadService extends Service {
 	}
 
 	public interface OnSongChangedListener {
-		void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex);
-		void onSongsChanged(List<DownloadFile> songs, DownloadFile currentPlaying, int currentPlayingIndex);
+		void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward);
+		void onSongsChanged(List<DownloadFile> songs, DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward);
 		void onSongProgress(DownloadFile currentPlaying, int millisPlayed, Integer duration, boolean isSeekable);
 		void onStateUpdate(DownloadFile downloadFile, PlayerState playerState);
 		void onMetadataUpdate(MusicDirectory.Entry entry, int fieldChange);

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -1202,7 +1202,7 @@ public class DownloadService extends Service {
 		}
 
 		// If only one song, just skip within song
-		if(size() == 1 || (currentPlaying != null && !currentPlaying.isSong())) {
+		if(size() == 1) {
 			rewind();
 			return;
 		}
@@ -1228,7 +1228,7 @@ public class DownloadService extends Service {
 	}
 	public synchronized void next(boolean forceCutoff, boolean forceStart) {
 		// If only one song, just skip within song
-		if(size() == 1 || (currentPlaying != null && !currentPlaying.isSong())) {
+		if(size() == 1) {
 			fastForward();
 			return;
 		} else if(playerState == PREPARING || playerState == PREPARED) {

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -1200,10 +1200,6 @@ public class DownloadService extends Service {
 	}
 
 	public synchronized void previous() {
-		if(playerState == PREPARING || playerState == PREPARED) {
-			return;
-		}
-
 		int index = getCurrentPlayingIndex();
 		if (index == -1) {
 			return;

--- a/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
@@ -68,9 +68,10 @@ public final class Notifications {
 		}
 		boolean remote = downloadService.isRemoteEnabled();
 		boolean isSingle = downloadService.isCurrentPlayingSingle();
+		boolean shouldFastForward = downloadService.shouldFastForward();
 		if (Build.VERSION.SDK_INT>= Build.VERSION_CODES.JELLY_BEAN){
 			RemoteViews expandedContentView = new RemoteViews(context.getPackageName(), R.layout.notification_expanded);
-			setupViews(expandedContentView ,context, song, true, playing, remote, isSingle);
+			setupViews(expandedContentView ,context, song, true, playing, remote, isSingle, shouldFastForward);
 			notification.bigContentView = expandedContentView;
 			notification.priority = Notification.PRIORITY_HIGH;
 		}
@@ -83,7 +84,7 @@ public final class Notifications {
 		}
 
 		RemoteViews smallContentView = new RemoteViews(context.getPackageName(), R.layout.notification);
-		setupViews(smallContentView, context, song, false, playing, remote, isSingle);
+		setupViews(smallContentView, context, song, false, playing, remote, isSingle, shouldFastForward);
 		notification.contentView = smallContentView;
 
 		Intent notificationIntent = new Intent(context, SubsonicFragmentActivity.class);
@@ -137,9 +138,7 @@ public final class Notifications {
 		DSubWidgetProvider.notifyInstances(context, downloadService, playing);
 	}
 
-	private static void setupViews(RemoteViews rv, Context context, MusicDirectory.Entry song, boolean expanded, boolean playing, boolean remote, boolean isSingleFile) {
-		boolean isLongFile = song.isAudioBook() || song.isPodcast();
-
+	private static void setupViews(RemoteViews rv, Context context, MusicDirectory.Entry song, boolean expanded, boolean playing, boolean remote, boolean isSingleFile, boolean shouldFastForward) {
 		// Use the same text for the ticker and the expanded notification
 		String title = song.getTitle();
 		String arist = song.getArtist();
@@ -174,7 +173,7 @@ public final class Notifications {
 			if(expanded) {
 				rv.setImageViewResource(R.id.control_pause, playing ? R.drawable.notification_pause : R.drawable.notification_start);
 
-				if(isLongFile && playing) {
+				if(shouldFastForward && playing) {
 					rv.setImageViewResource(R.id.control_previous, R.drawable.notification_rewind);
 					rv.setImageViewResource(R.id.control_next, R.drawable.notification_fastforward);
 				} else {
@@ -183,14 +182,14 @@ public final class Notifications {
 				}
 			} else {
 				rv.setImageViewResource(R.id.control_previous, playing ? R.drawable.notification_pause : R.drawable.notification_start);
-				if(isLongFile && playing) {
+				if(shouldFastForward && playing) {
 					rv.setImageViewResource(R.id.control_pause, R.drawable.notification_fastforward);
 				} else {
 					rv.setImageViewResource(R.id.control_pause, R.drawable.notification_forward);
 				}
 				rv.setImageViewResource(R.id.control_next, R.drawable.notification_close);
 			}
-		} else if(isLongFile) {
+		} else if(shouldFastForward) {
 			rv.setImageViewResource(R.id.control_previous, R.drawable.notification_rewind);
 			rv.setImageViewResource(R.id.control_next, R.drawable.notification_fastforward);
 		} else {
@@ -202,7 +201,7 @@ public final class Notifications {
 		// Create actions for media buttons
 		int previous = 0, pause = 0, next = 0, close = 0, rewind = 0, fastForward = 0;
 		if (expanded) {
-			if (isLongFile && playing) {
+			if (shouldFastForward && playing) {
 				rewind = R.id.control_previous;
 				pause = R.id.control_pause;
 				fastForward = R.id.control_next;
@@ -219,7 +218,7 @@ public final class Notifications {
 		} else {
 			if (persistent) {
 				pause = R.id.control_previous;
-				if(isLongFile && playing) {
+				if(shouldFastForward && playing) {
 					fastForward = R.id.control_pause;
 				} else {
 					next = R.id.control_pause;

--- a/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
@@ -173,7 +173,7 @@ public final class Notifications {
 			if(expanded) {
 				rv.setImageViewResource(R.id.control_pause, playing ? R.drawable.notification_pause : R.drawable.notification_start);
 
-				if(shouldFastForward && playing) {
+				if(shouldFastForward) {
 					rv.setImageViewResource(R.id.control_previous, R.drawable.notification_rewind);
 					rv.setImageViewResource(R.id.control_next, R.drawable.notification_fastforward);
 				} else {
@@ -182,7 +182,7 @@ public final class Notifications {
 				}
 			} else {
 				rv.setImageViewResource(R.id.control_previous, playing ? R.drawable.notification_pause : R.drawable.notification_start);
-				if(shouldFastForward && playing) {
+				if(shouldFastForward) {
 					rv.setImageViewResource(R.id.control_pause, R.drawable.notification_fastforward);
 				} else {
 					rv.setImageViewResource(R.id.control_pause, R.drawable.notification_forward);
@@ -201,7 +201,7 @@ public final class Notifications {
 		// Create actions for media buttons
 		int previous = 0, pause = 0, next = 0, close = 0, rewind = 0, fastForward = 0;
 		if (expanded) {
-			if (shouldFastForward && playing) {
+			if (shouldFastForward) {
 				rewind = R.id.control_previous;
 				pause = R.id.control_pause;
 				fastForward = R.id.control_next;
@@ -218,7 +218,7 @@ public final class Notifications {
 		} else {
 			if (persistent) {
 				pause = R.id.control_previous;
-				if(shouldFastForward && playing) {
+				if(shouldFastForward) {
 					fastForward = R.id.control_pause;
 				} else {
 					next = R.id.control_pause;

--- a/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
@@ -200,31 +200,38 @@ public final class Notifications {
 		}
 
 		// Create actions for media buttons
-		PendingIntent pendingIntent;
 		int previous = 0, pause = 0, next = 0, close = 0, rewind = 0, fastForward = 0;
-		if(persistent && !expanded) {
-			pause = R.id.control_previous;
-			if(isLongFile && playing) {
-				fastForward = R.id.control_pause;
+		if (expanded) {
+			if (isLongFile && playing) {
+				rewind = R.id.control_previous;
+				pause = R.id.control_pause;
+				fastForward = R.id.control_next;
 			} else {
-				next = R.id.control_pause;
+				previous = R.id.control_previous;
+				pause = R.id.control_pause;
+				next = R.id.control_next;
 			}
-			close = R.id.control_next;
-		} else if(isLongFile && (!persistent || (expanded && playing))) {
-			rewind = R.id.control_previous;
-			pause = R.id.control_pause;
-			fastForward = R.id.control_next;
+
+			if (remote || persistent) {
+				close = R.id.notification_close;
+				rv.setViewVisibility(close, View.VISIBLE);
+			}
 		} else {
-			previous = R.id.control_previous;
-			pause = R.id.control_pause;
-			next = R.id.control_next;
+			if (persistent) {
+				pause = R.id.control_previous;
+				if(isLongFile && playing) {
+					fastForward = R.id.control_pause;
+				} else {
+					next = R.id.control_pause;
+				}
+				close = R.id.control_next;
+			} else {
+				rewind = R.id.control_previous;
+				pause = R.id.control_pause;
+				fastForward = R.id.control_next;
+			}
 		}
 
-		if((remote || persistent) && close == 0 && expanded) {
-			close = R.id.notification_close;
-			rv.setViewVisibility(close, View.VISIBLE);
-		}
-		
 		if(isSingleFile) {
 			if(previous > 0) {
 				rv.setViewVisibility(previous, View.GONE);
@@ -246,6 +253,7 @@ public final class Notifications {
 			}
 		}
 
+		PendingIntent pendingIntent;
 		if(previous > 0) {
 			Intent prevIntent = new Intent("KEYCODE_MEDIA_PREVIOUS");
 			prevIntent.setComponent(new ComponentName(context, DownloadService.class));


### PR DESCRIPTION
While playing a long song (audiobook, in my case), the buttons on the notification change between rewind/fast forward and previous/next depending on whether or not the song is playing.  However, the previous/next buttons still rewind/fast forward even though they are using the previous/next icons and running the previous/next intents.

It turns out that there is a separate check for if it's an audiobook or podcast (rather, is not a song) in the actual previous/next DownloadService methods.  I would guess this was added in before the icon swapping was added, though I haven't checked that in the code.  Whether or not it's a long song is checked for in the IF block in Notifications.java lines 173-200.

A few minor other changes that aren't actually related to fixing the bug:
I rewrote an If/elif/else statement - this was mostly because I was having major trouble trying to follow how the flow of the statement went.  Mine is a few lines longer but easier to follow (for me, at least, but then, I wrote it...).

I moved the PendingIntent declaration down to where it gets used since I had to dig around to find it.  I can move it back if you want it declared at the start of the 'media button action' creation section instead of just before the If statements it's used in.