### PR TITLE
Changes AA song selection to play the directory

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/service/AutoMediaBrowserService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/AutoMediaBrowserService.java
@@ -279,12 +279,18 @@ public class AutoMediaBrowserService extends MediaBrowserService {
 
 				// music files
 				for(Entry entry: indexes.getEntries()) {
+					entry.setBookmark(null);    // don't resume from a bookmark in a browse listing
+					Bundle extras = new Bundle();
+					extras.putSerializable(Constants.INTENT_EXTRA_ENTRY, entry);
+					extras.putString(Constants.INTENT_EXTRA_NAME_CHILD_ID, entry.getId());
+
 					MediaDescription description = new MediaDescription.Builder()
 							.setTitle(entry.getTitle())
-							.setMediaId(MUSIC_DIRECTORY_PREFIX + entry.getId())
+							.setMediaId(entry.getId())
+							.setExtras(extras)
 							.build();
 
-					mediaItems.add(new MediaBrowser.MediaItem(description, MediaBrowser.MediaItem.FLAG_BROWSABLE));
+					mediaItems.add(new MediaBrowser.MediaItem(description, MediaBrowser.MediaItem.FLAG_PLAYABLE));
 				}
 
 				result.sendResult(mediaItems);
@@ -315,15 +321,24 @@ public class AutoMediaBrowserService extends MediaBrowserService {
 								.setTitle(entry.getTitle())
 								.setMediaId(MUSIC_DIRECTORY_CONTENTS_PREFIX + entry.getId())
 								.build();
+
+						mediaItems.add(new MediaBrowser.MediaItem(description, MediaBrowser.MediaItem.FLAG_BROWSABLE));
 					} else {
-						// playback options for a single item
+						// mark individual songs as directly playable
+						entry.setBookmark(null);    // don't resume from a bookmark in a browse listing
+						Bundle extras = new Bundle();
+						extras.putSerializable(Constants.INTENT_EXTRA_ENTRY, entry);
+						extras.putString(Constants.INTENT_EXTRA_NAME_CHILD_ID, entry.getId());
+
 						description = new MediaDescription.Builder()
 								.setTitle(entry.getTitle())
-								.setMediaId(MUSIC_DIRECTORY_PREFIX + entry.getId())
+								.setMediaId(entry.getId())
+								.setExtras(extras)
 								.build();
+
+						mediaItems.add(new MediaBrowser.MediaItem(description, MediaBrowser.MediaItem.FLAG_PLAYABLE));
 					}
 
-					mediaItems.add(new MediaBrowser.MediaItem(description, MediaBrowser.MediaItem.FLAG_BROWSABLE));
 				}
 				result.sendResult(mediaItems);
 			}

--- a/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientLP.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientLP.java
@@ -564,7 +564,7 @@ public class RemoteControlClientLP extends RemoteControlClientBase {
 				playSong(entry, true);
 			}
 
-			// Currently only happens when playing bookmarks so we should be looking up parent
+			// Enqueue an entire directory when selecting a bookmark or a song
 			String childId = extras.getString(Constants.INTENT_EXTRA_NAME_CHILD_ID, null);
 			if(childId != null) {
 				if(Util.isTagBrowsing(downloadService) && !Util.isOffline(downloadService)) {


### PR DESCRIPTION
Instead of showing an advanced (not working, incidentally) menu of Play/Shuffle/PlayLast options when selecting a song, enqueue the directory and start playback at the selected song, similar to how bookmarks behave.
It relies on #841 to play the selected song after enqueueing the directory.