### PR TITLE
Add option to disable downloading while roaming

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
@@ -1364,7 +1364,7 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		switch (playerState) {
 			case DOWNLOADING:
 				if(currentPlaying != null) {
-					if(Util.isWifiRequiredForDownload(context)) {
+					if(Util.isWifiRequiredForDownload(context) || Util.isLocalNetworkRequiredForDownload(context)) {
 						statusTextView.setText(context.getResources().getString(R.string.download_playerstate_mobile_disabled));
 					} else {
 						long bytes = currentPlaying.getPartialFile().length();

--- a/app/src/main/java/github/daneren2005/dsub/util/Constants.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Constants.java
@@ -103,6 +103,7 @@ public final class Constants {
     public static final String PREFERENCES_KEY_SCROBBLE = "scrobble";
     public static final String PREFERENCES_KEY_REPEAT_MODE = "repeatMode";
     public static final String PREFERENCES_KEY_WIFI_REQUIRED_FOR_DOWNLOAD = "wifiRequiredForDownload";
+    public static final String PREFERENCES_KEY_LOCAL_NETWORK_REQUIRED_FOR_DOWNLOAD = "localNetworkRequiredForDownload";
 	public static final String PREFERENCES_KEY_RANDOM_SIZE = "randomSize";
 	public static final String PREFERENCES_KEY_SLEEP_TIMER_DURATION = "sleepTimerDuration";
 	public static final String PREFERENCES_KEY_OFFLINE = "offline";

--- a/app/src/main/java/github/daneren2005/dsub/util/Util.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Util.java
@@ -36,6 +36,7 @@ import android.graphics.drawable.Drawable;
 import android.media.AudioManager;
 import android.media.AudioManager.OnAudioFocusChangeListener;
 import android.net.ConnectivityManager;
+import android.net.Network;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 import android.os.Build;
@@ -1082,7 +1083,10 @@ public final class Util {
 			boolean wifiConnected = connected && networkInfo.getType() == ConnectivityManager.TYPE_WIFI;
 			boolean wifiRequired = isWifiRequiredForDownload(context);
 
-			return connected && (!wifiRequired || wifiConnected);
+			boolean isLocalNetwork = connected && !networkInfo.isRoaming();
+			boolean localNetworkRequired = isLocalNetworkRequiredForDownload(context);
+
+			return connected && (!wifiRequired || wifiConnected) && (!localNetworkRequired || isLocalNetwork);
 		} else {
 			return connected;
 		}
@@ -1114,6 +1118,11 @@ public final class Util {
     public static boolean isWifiRequiredForDownload(Context context) {
         SharedPreferences prefs = getPreferences(context);
         return prefs.getBoolean(Constants.PREFERENCES_KEY_WIFI_REQUIRED_FOR_DOWNLOAD, false);
+    }
+
+    public static boolean isLocalNetworkRequiredForDownload(Context context) {
+        SharedPreferences prefs = getPreferences(context);
+        return prefs.getBoolean(Constants.PREFERENCES_KEY_LOCAL_NETWORK_REQUIRED_FOR_DOWNLOAD, false);
     }
 
     public static void info(Context context, int titleId, int messageId) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -168,7 +168,7 @@
     <string name="download.empty">Wiedergabeliste ist leer</string>
 	<string name="download.shuffle_loading">Wiedergabeliste wird gemischt...</string>
     <string name="download.playerstate_downloading">Downloade - %s</string>
-	 <string name="download.playerstate_mobile_disabled">Warte auf Wi-Fi für den Download</string>
+	 <string name="download.playerstate_mobile_disabled">Warte auf Wi-Fi oder lokales Netzwerk für den Download</string>
     <string name="download.playerstate_buffering">Buffere</string>
     <string name="download.playerstate_playing_shuffle">Playing shuffle</string>
     <string name="download.menu_show_album">Zeige Album</string>
@@ -301,6 +301,8 @@
     <string name="settings.max_bitrate_unlimited">Unbegrenzt</string>
     <string name="settings.wifi_required_title">Nur Wi-Fi streaming</string>
     <string name="settings.wifi_required_summary">Medien nur streamen, wenn mit Wi-Fi verbunden</string>
+    <string name="settings.local_network_required_title">Kein streaming mit Roaming-Netzwerken</string>
+    <string name="settings.local_network_required_summary">Medien nur streamen, wenn mit lokalem Anbieter verbunden</string>
 	<string name="settings.network_timeout_title">Netzwerk Timeout</string>
 	<string name="settings.network_timeout_10000">10 Sekunden</string>
 	<string name="settings.network_timeout_15000">15 Sekunden</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,7 +180,7 @@
     <string name="download.empty">Playlist is empty</string>
 	<string name="download.shuffle_loading">Shuffle list is loading...</string>
     <string name="download.playerstate_downloading">Downloading - %s</string>
-	<string name="download.playerstate_mobile_disabled">Waiting for WiFi network to download</string>
+	<string name="download.playerstate_mobile_disabled">Waiting for WiFi or local (non-roaming) network to download</string>
     <string name="download.playerstate_buffering">Buffering</string>
     <string name="download.playerstate_playing_shuffle">Shuffle mode</string>
 	<string name="download.playerstate_playing_artist_radio">Artist radio</string>
@@ -346,6 +346,8 @@
     <string name="settings.max_bitrate_unlimited">Unlimited</string>
     <string name="settings.wifi_required_title">Wi-Fi streaming only</string>
     <string name="settings.wifi_required_summary">Only stream media if connected to Wi-Fi</string>
+    <string name="settings.local_network_required_title">Don\'t stream when roaming</string>
+    <string name="settings.local_network_required_summary">Don\'t stream media while roaming</string>
 	<string name="settings.network_timeout_title">Network Timeout</string>
 	<string name="settings.network_timeout_10000">10 seconds</string>
 	<string name="settings.network_timeout_15000">15 seconds</string>

--- a/app/src/main/res/xml/settings_cache.xml
+++ b/app/src/main/res/xml/settings_cache.xml
@@ -40,6 +40,12 @@
 			android:key="wifiRequiredForDownload"
 			android:defaultValue="false"/>
 
+		<CheckBoxPreference
+			android:title="@string/settings.local_network_required_title"
+			android:summary="@string/settings.local_network_required_summary"
+			android:key="localNetworkRequiredForDownload"
+			android:defaultValue="false"/>
+
 		<ListPreference
 			android:title="@string/settings.network_timeout_title"
 			android:key="networkTimeout"


### PR DESCRIPTION
Currently untested, and my first contribution ever to an Android (or Java) project :sweat_smile: 

I recently forgot to turn on WiFi abroad and used up my 250MB roaming data pretty quickly (I don't want to disable mobile streaming entirely because I have unlimited data when not abroad).

I probably won't be able to test it in the next two weeks or so though - but hey, it compiles, ship it™ :ship: :wink: