### PR TITLE
Fix a crash on getRecentDownloads if playlist is empty

### DIFF
--- a/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
+++ b/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
@@ -49,6 +49,20 @@ public class DownloadServiceTest extends
 		assertEquals(0, position);
 	}
 
+	public void testGetRecentDownloadsWithoutPlaylist() {
+		int output_length = downloadService.getRecentDownloads().size();
+		assertEquals(0, output_length);
+	}
+
+	public void testGetRecentDownloadsWithPlaylist() {
+		downloadService.getDownloads().clear();
+		downloadService.download(this.createMusicSongs(2), false, false, false,
+				false, 0, 0);
+
+		int output_length = downloadService.getRecentDownloads().size();
+		assertEquals(1, output_length);
+	}
+
 	public void testGetCurrentPlayingIndexWithoutPlayList() {
 		int currentPlayingIndex = activity.getDownloadService()
 				.getCurrentPlayingIndex();

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -1060,7 +1060,7 @@ public class DownloadService extends Service {
 	public synchronized List<DownloadFile> getRecentDownloads() {
 		int from = Math.max(currentPlayingIndex - 10, 0);
 		int songsToKeep = Math.max(Util.getPreloadCount(this), 20);
-		int to = Math.min(currentPlayingIndex + songsToKeep, downloadList.size() - 1);
+		int to = Math.min(currentPlayingIndex + songsToKeep, Math.max(downloadList.size() - 1, 0));
 		List<DownloadFile> temp = downloadList.subList(from, to);
 		temp.addAll(backgroundDownloadList);
 		return temp;


### PR DESCRIPTION
If the current download list is empty then there is we attempt to get from index 0 to index -1, throwing a range error. This cleans that up and adds a test to validate.

I've got no idea whether this is causing any actual issues, I just stumbled across this on my hunt for something else.