### PR TITLE
Fix Genre comparator to pass unit tests

### DIFF
--- a/app/src/androidTest/java/github/daneren2005/dsub/domain/GenreComparatorTest.java
+++ b/app/src/androidTest/java/github/daneren2005/dsub/domain/GenreComparatorTest.java
@@ -16,7 +16,7 @@ public class GenreComparatorTest extends TestCase {
 
 		Genre g2 = new Genre();
 		
-		List<Genre> genres = new ArrayList<Genre>();
+		List<Genre> genres = new ArrayList<>();
 		genres.add(g1);
 		genres.add(g2);
 		
@@ -34,7 +34,7 @@ public class GenreComparatorTest extends TestCase {
 		Genre g2 = new Genre();
 		g2.setName("genre");
 		
-		List<Genre> genres = new ArrayList<Genre>();
+		List<Genre> genres = new ArrayList<>();
 		genres.add(g1);
 		genres.add(g2);
 		
@@ -53,9 +53,9 @@ public class GenreComparatorTest extends TestCase {
 		g2.setName("Pop");
 		
 		Genre g3 = new Genre();
-		g2.setName("Rap");
+		g3.setName("Rap");
 		
-		List<Genre> genres = new ArrayList<Genre>();
+		List<Genre> genres = new ArrayList<>();
 		genres.add(g1);
 		genres.add(g2);
 		genres.add(g3);

--- a/app/src/main/java/github/daneren2005/dsub/domain/Genre.java
+++ b/app/src/main/java/github/daneren2005/dsub/domain/Genre.java
@@ -1,15 +1,9 @@
 package github.daneren2005.dsub.domain;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
-import github.daneren2005.dsub.util.Constants;
-import github.daneren2005.dsub.util.Util;
 
 public class Genre implements Serializable {
 	private String name;
@@ -57,7 +51,10 @@ public class Genre implements Serializable {
 	public static class GenreComparator implements Comparator<Genre> {
 		@Override
 		public int compare(Genre genre1, Genre genre2) {
-			return genre1.getName().compareToIgnoreCase(genre2.getName());
+			String genre1Name = genre1.getName() != null ? genre1.getName() : "";
+			String genre2Name = genre2.getName() != null ? genre2.getName() : "";
+
+			return genre1Name.compareToIgnoreCase(genre2Name);
 		}
 
 		public static List<Genre> sort(List<Genre> genres) {


### PR DESCRIPTION
Fixes a bug in genre comparator unit test, and a bug in the genre comparator itself where null values aren't handled