### PR TITLE
Fix failing test #916

### DIFF
--- a/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
+++ b/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
@@ -132,6 +132,7 @@ public class DownloadServiceTest extends
 		// Do a next before the previous
 		downloadService.next();
 
+		downloadService.setPlayerState(STARTED);
 		// Do the previous
 		downloadService.previous();
 


### PR DESCRIPTION
Testing previous relies on the player state. The test in it's current form relies on too many side effects  for a good unit test. Setting the player state manually for now.