### PR TITLE
Stop current track if rated bad and empty playlist

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -2806,14 +2806,16 @@ public class DownloadService extends Service {
 	}
 	public void setRating(int rating) {
 		final DownloadFile currentPlaying = this.currentPlaying;
-		if(currentPlaying == null) {
+		if (currentPlaying == null) {
 			return;
 		}
 		MusicDirectory.Entry entry = currentPlaying.getSong();
 
 		// Immediately skip to the next song if down thumbed
-		if(rating == 1) {
+		if (rating == 1 && size() > 1) {
 			next(true);
+		} else if (rating == 1 && size() == 1) {
+			stop();
 		}
 
 		UpdateHelper.setRating(this, entry, rating, new UpdateHelper.OnRatingChange() {


### PR DESCRIPTION
Current behaviour: If there are no other tracks in the playlist and you rate the playing song as bad it skips forward by 30 seconds.

This patch changes that behaviour to stop the track in this situation.

I have a test but Mockito isn't working with android properly at the moment so I'll need to follow up with that when they resolve.