### PR TITLE
Fix Chromecast routes

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientLP.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientLP.java
@@ -207,12 +207,12 @@ public class RemoteControlClientLP extends RemoteControlClientBase {
 
 	@Override
 	public void registerRoute(MediaRouter router) {
-		router.setMediaSession(mediaSession);
+		router.setMediaSessionCompat(mediaSession);
 	}
 
 	@Override
 	public void unregisterRoute(MediaRouter router) {
-		router.setMediaSession(null);
+		router.setMediaSessionCompat(null);
 	}
 
 	@Override


### PR DESCRIPTION
Due to the migrating from commit https://github.com/daneren2005/Subsonic/commit/90f6cd02b7968bd3f10d3a4ddd6f2a32cce3ca46, `router.setMediaSession(mediaSession);` is no longer valid, as it expects a MediaSession object and not a MediaSessionCompat object. This exception causes the app to crash unexpectedly.

Also see https://developer.android.com/reference/android/support/v7/media/MediaRouter#setmediasessioncompat