### PR TITLE
Changed home screen widgets to show rewind/fast forward correctly

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/provider/DSubWidgetProvider.java
+++ b/app/src/main/java/github/daneren2005/dsub/provider/DSubWidgetProvider.java
@@ -217,6 +217,19 @@ public class DSubWidgetProvider extends AppWidgetProvider {
             views.setImageViewResource(R.id.control_play, R.drawable.media_start_dark);
         }
 
+        // Hide and show correct previous/next and rewind/fast forward buttons
+        if (service != null && service.shouldFastForward()) {
+            views.setViewVisibility(R.id.control_previous, View.GONE);
+            views.setViewVisibility(R.id.control_next, View.GONE);
+            views.setViewVisibility(R.id.control_rewind, View.VISIBLE);
+            views.setViewVisibility(R.id.control_fastforward, View.VISIBLE);
+        } else {
+            views.setViewVisibility(R.id.control_previous, View.VISIBLE);
+            views.setViewVisibility(R.id.control_next, View.VISIBLE);
+            views.setViewVisibility(R.id.control_rewind, View.GONE);
+            views.setViewVisibility(R.id.control_fastforward, View.GONE);
+        }
+
         // Set the cover art
         try {
             boolean large = false;
@@ -301,5 +314,17 @@ public class DSubWidgetProvider extends AppWidgetProvider {
 		intent.setAction(DownloadService.CMD_PREVIOUS);
         pendingIntent = PendingIntent.getService(context, 0, intent, 0);
         views.setOnClickPendingIntent(R.id.control_previous, pendingIntent);
+
+        intent = new Intent("DSub.REWIND");  // Use a unique action name to ensure a different PendingIntent to be created.
+        intent.setComponent(new ComponentName(context, DownloadService.class));
+        intent.setAction(DownloadService.CMD_REWIND);
+        pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+        views.setOnClickPendingIntent(R.id.control_rewind, pendingIntent);
+
+        intent = new Intent("DSub.FASTFORWARD");  // Use a unique action name to ensure a different PendingIntent to be created.
+        intent.setComponent(new ComponentName(context, DownloadService.class));
+        intent.setAction(DownloadService.CMD_FASTFORWARD);
+        pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+        views.setOnClickPendingIntent(R.id.control_fastforward, pendingIntent);
     }
 }

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -109,6 +109,8 @@ public class DownloadService extends Service {
 	public static final String CMD_STOP = "github.daneren2005.dsub.CMD_STOP";
 	public static final String CMD_PREVIOUS = "github.daneren2005.dsub.CMD_PREVIOUS";
 	public static final String CMD_NEXT = "github.daneren2005.dsub.CMD_NEXT";
+	public static final String CMD_REWIND = "github.daneren2005.dsub.CMD_REWIND";
+	public static final String CMD_FASTFORWARD = "github.daneren2005.dsub.CMD_FASTFORWARD";
 	public static final String CANCEL_DOWNLOADS = "github.daneren2005.dsub.CANCEL_DOWNLOADS";
 	public static final String START_PLAY = "github.daneren2005.dsub.START_PLAYING";
 	private static final long DEFAULT_DELAY_UPDATE_PROGRESS = 1000L;

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadServiceLifecycleSupport.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadServiceLifecycleSupport.java
@@ -89,6 +89,10 @@ public class DownloadServiceLifecycleSupport {
 						downloadService.next();
 					} else if (DownloadService.CMD_PREVIOUS.equals(action)) {
 						downloadService.previous();
+					} else if (DownloadService.CMD_FASTFORWARD.equals(action)) {
+						downloadService.fastForward();
+					} else if (DownloadService.CMD_REWIND.equals(action)) {
+						downloadService.rewind();
 					} else if (DownloadService.CMD_TOGGLEPAUSE.equals(action)) {
 						downloadService.togglePlayPause();
 					} else if (DownloadService.CMD_PAUSE.equals(action)) {
@@ -170,6 +174,8 @@ public class DownloadServiceLifecycleSupport {
 		commandFilter.addAction(DownloadService.CMD_STOP);
 		commandFilter.addAction(DownloadService.CMD_PREVIOUS);
 		commandFilter.addAction(DownloadService.CMD_NEXT);
+		commandFilter.addAction(DownloadService.CMD_REWIND);
+		commandFilter.addAction(DownloadService.CMD_FASTFORWARD);
 		commandFilter.addAction(DownloadService.CANCEL_DOWNLOADS);
 		downloadService.registerReceiver(intentReceiver, commandFilter);
 
@@ -241,6 +247,10 @@ public class DownloadServiceLifecycleSupport {
 						downloadService.next();
 					} else if(DownloadService.CMD_PREVIOUS.equals(action)) {
 						downloadService.previous();
+					} else if(DownloadService.CMD_REWIND.equals(action)) {
+						downloadService.rewind();
+					} else if(DownloadService.CMD_FASTFORWARD.equals(action)) {
+						downloadService.fastForward();
 					} else if(DownloadService.CANCEL_DOWNLOADS.equals(action)) {
 						downloadService.clearBackground();
 					} else if(intent.getExtras() != null) {

--- a/app/src/main/res/layout/appwidget4x1.xml
+++ b/app/src/main/res/layout/appwidget4x1.xml
@@ -82,6 +82,15 @@
             android:orientation="horizontal">
 
             <ImageButton
+                android:id="@+id/control_rewind"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_rewind_dark"
+                android:visibility="gone" />
+
+            <ImageButton
                 android:id="@+id/control_previous"
                 android:layout_width="0dip"
                 android:layout_height="fill_parent"
@@ -104,6 +113,15 @@
                 android:layout_weight="1"
                 android:src="@drawable/media_forward_dark"
 				style="@style/NotificationButton" />
+
+            <ImageButton
+                android:id="@+id/control_fastforward"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_fastforward_dark"
+                android:visibility="gone" />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/appwidget4x2.xml
+++ b/app/src/main/res/layout/appwidget4x2.xml
@@ -108,6 +108,15 @@
             android:paddingTop="4dip" >
 
             <ImageButton
+                android:id="@+id/control_rewind"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_rewind_dark"
+                android:visibility="gone" />
+
+            <ImageButton
                 android:id="@+id/control_previous"
                 android:layout_width="0dip"
                 android:layout_height="wrap_content"
@@ -130,6 +139,15 @@
                 android:layout_weight="1"
                 android:src="@drawable/media_forward_dark"
 				style="@style/NotificationButton" />
+
+            <ImageButton
+                android:id="@+id/control_fastforward"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_fastforward_dark"
+                android:visibility="gone" />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/appwidget4x3.xml
+++ b/app/src/main/res/layout/appwidget4x3.xml
@@ -90,6 +90,15 @@
             android:paddingBottom="4dip">
 
             <ImageButton
+                android:id="@+id/control_rewind"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_rewind_dark"
+                android:visibility="gone" />
+
+            <ImageButton
                 android:id="@+id/control_previous"
                 android:layout_width="0dip"
                 android:layout_height="56dip"
@@ -112,6 +121,15 @@
                 android:layout_weight="1"
                 android:src="@drawable/media_forward_dark"
 				style="@style/NotificationButton" />
+
+            <ImageButton
+                android:id="@+id/control_fastforward"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_fastforward_dark"
+                android:visibility="gone" />
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/appwidget4x4.xml
+++ b/app/src/main/res/layout/appwidget4x4.xml
@@ -26,7 +26,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-       <LinearLayout
+        <LinearLayout
             android:id="@+id/appwidget_top"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
@@ -92,6 +92,15 @@
             android:paddingTop="4dip" >
 
             <ImageButton
+                android:id="@+id/control_rewind"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_rewind_dark"
+                android:visibility="gone" />
+
+            <ImageButton
                 android:id="@+id/control_previous"
                 android:layout_width="0dip"
                 android:layout_height="56dip"
@@ -114,6 +123,15 @@
                 android:layout_weight="1"
                 android:src="@drawable/media_forward_dark"
 				style="@style/NotificationButton" />
+
+            <ImageButton
+                android:id="@+id/control_fastforward"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="1"
+                style="@style/NotificationButton"
+                android:src="@drawable/media_fastforward_dark"
+                android:visibility="gone" />
         </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
Changes the home screen widgets to show rewind/fast forward when appropriate instead of only every showing previous/next.  This will better match the Now Playing fragment and notifications.

Meant to work with code submitted in PR #940, specifically the changes in DownloadService.  If that PR is not merged but you do want this one merged, I will add a commit to make that change so previous/next always go previous/next instead of going rewind/fastforward in some cases.