### PR TITLE
Bugfix for widget PendingIntents on Android Oreo and higher

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/provider/DSubWidgetProvider.java
+++ b/app/src/main/java/github/daneren2005/dsub/provider/DSubWidgetProvider.java
@@ -34,6 +34,7 @@ import android.graphics.PorterDuff.Mode;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
 import android.view.View;
@@ -282,24 +283,33 @@ public class DSubWidgetProvider extends AppWidgetProvider {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
         views.setOnClickPendingIntent(R.id.appwidget_coverart, pendingIntent);
         views.setOnClickPendingIntent(R.id.appwidget_top, pendingIntent);
-        
+
         // Emulate media button clicks.
         intent = new Intent("DSub.PLAY_PAUSE");
         intent.setComponent(new ComponentName(context, DownloadService.class));
 		intent.setAction(DownloadService.CMD_TOGGLEPAUSE);
-        pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+        if (Build.VERSION.SDK_INT >= 26)
+            pendingIntent = PendingIntent.getForegroundService(context, 0, intent, 0);
+        else
+            pendingIntent = PendingIntent.getService(context, 0, intent, 0);
         views.setOnClickPendingIntent(R.id.control_play, pendingIntent);
 
         intent = new Intent("DSub.NEXT");  // Use a unique action name to ensure a different PendingIntent to be created.
         intent.setComponent(new ComponentName(context, DownloadService.class));
 		intent.setAction(DownloadService.CMD_NEXT);
-        pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+        if (Build.VERSION.SDK_INT >= 26)
+            pendingIntent = PendingIntent.getForegroundService(context, 0, intent, 0);
+        else
+            pendingIntent = PendingIntent.getService(context, 0, intent, 0);
         views.setOnClickPendingIntent(R.id.control_next, pendingIntent);
-        
+
         intent = new Intent("DSub.PREVIOUS");  // Use a unique action name to ensure a different PendingIntent to be created.
         intent.setComponent(new ComponentName(context, DownloadService.class));
 		intent.setAction(DownloadService.CMD_PREVIOUS);
-        pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+        if (Build.VERSION.SDK_INT >= 26)
+            pendingIntent = PendingIntent.getForegroundService(context, 0, intent, 0);
+        else
+            pendingIntent = PendingIntent.getService(context, 0, intent, 0);
         views.setOnClickPendingIntent(R.id.control_previous, pendingIntent);
     }
 }


### PR DESCRIPTION
When attempting to play music from the home screen widgets on Android 8 and higher, if the DownloadService has been stopped by the OS due to its idle state, the service fails to start and this message is logged:

`W/ActivityManager: Background start not allowed: service Intent { act=github.daneren2005.dsub.CMD_TOGGLEPAUSE flg=0x10000000 cmp=github.daneren2005.dsub/.service.DownloadService bnds=[697,1868][1059,2010] } to github.daneren2005.dsub/.service.DownloadService from pid=-1 uid=10316 pkg=github.daneren2005.dsub startFg?=false`

Instead, the service needs to be started as a foreground service.  I have created that fix in this PR.

Interestingly, the notifications didn't need to be fixed because notifications are exempted from this limitation.  Note the whitelisted intents here: https://developer.android.com/about/versions/oreo/background

This is related to #880.