### PR TITLE
Bugfix for pause on losing focus

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/util/Util.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Util.java
@@ -1340,6 +1340,7 @@ public final class Util {
 				audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
 						.setAudioAttributes(playbackAttributes)
 						.setOnAudioFocusChangeListener(getAudioFocusChangeListener(context, audioManager))
+						.setWillPauseWhenDucked(true)
 						.build();
 				audioManager.requestAudioFocus(audioFocusRequest);
 			}


### PR DESCRIPTION
Since Android O when losing focus with TRANSIENT_MAY_DUCK the app would no longer run onAudioFocusChange resulting in the alway pause on losing focus not working.
This fixes that.