### PR TITLE
Settings: Remove overly zealous URL validation

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/fragments/SettingsFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/SettingsFragment.java
@@ -803,9 +803,6 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 						try {
 							String url = (String) value;
 							new URL(url);
-							if (url.contains(" ") || url.contains("@")) {
-								throw new Exception();
-							}
 						} catch (Exception x) {
 							new ErrorDialog(context, R.string.settings_invalid_url, false);
 							return false;
@@ -824,9 +821,6 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 							}
 
 							new URL(url);
-							if (url.contains(" ") || url.contains("@")) {
-								throw new Exception();
-							}
 						} catch (Exception x) {
 							new ErrorDialog(context, R.string.settings_invalid_url, false);
 							return false;


### PR DESCRIPTION
Server URLs were checked if they contain an '@' or ' ' (space) and
rejected. This is wrong, an URL may contain an @ sign to provide
basic-auth parameters as part of the URL and works just fine.

We should leave URL validation to libraries dealing with URLs. With this
change it's now possible to connect to a subsonic server protected by
basic-auth, as long as the basic-auth credentials match the subsonic
credentials.