### PR TITLE
Fallback to default media receiver application when Google casting

### DIFF
--- a/app/src/google/java/github/daneren2005/dsub/service/ChromeCastController.java
+++ b/app/src/google/java/github/daneren2005/dsub/service/ChromeCastController.java
@@ -49,6 +49,8 @@ import github.daneren2005.serverproxy.FileProxy;
 import github.daneren2005.serverproxy.ServerProxy;
 import github.daneren2005.serverproxy.WebProxy;
 
+import static github.daneren2005.dsub.util.compat.GoogleCompat.castApplicationId;
+
 /**
  * Created by owner on 2/9/14.
  */
@@ -421,14 +423,14 @@ public class ChromeCastController extends RemoteController {
 
 		void launchApplication() {
 			try {
-				Cast.CastApi.launchApplication(apiClient, EnvironmentVariables.CAST_APPLICATION_ID, false).setResultCallback(resultCallback);
+				Cast.CastApi.launchApplication(apiClient, castApplicationId(), false).setResultCallback(resultCallback);
 			} catch (Exception e) {
 				Log.e(TAG, "Failed to launch application", e);
 			}
 		}
 		void reconnectApplication() {
 			try {
-				Cast.CastApi.joinApplication(apiClient, EnvironmentVariables.CAST_APPLICATION_ID, sessionId).setResultCallback(resultCallback);
+				Cast.CastApi.joinApplication(apiClient, castApplicationId(), sessionId).setResultCallback(resultCallback);
 			} catch (Exception e) {
 				Log.e(TAG, "Failed to reconnect application", e);
 			}

--- a/app/src/google/java/github/daneren2005/dsub/util/compat/GoogleCompat.java
+++ b/app/src/google/java/github/daneren2005/dsub/util/compat/GoogleCompat.java
@@ -9,6 +9,7 @@ import com.google.android.gms.cast.CastMediaControlIntent;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.security.ProviderInstaller;
+import static com.google.android.gms.cast.CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID;
 
 import github.daneren2005.dsub.service.ChromeCastController;
 import github.daneren2005.dsub.service.DownloadService;
@@ -32,10 +33,17 @@ public final class GoogleCompat {
         ProviderInstaller.installIfNeeded(context);
     }
 
+    public static String castApplicationId() {
+        if (EnvironmentVariables.CAST_APPLICATION_ID != null) {
+            return EnvironmentVariables.CAST_APPLICATION_ID;
+        } else {
+            return DEFAULT_MEDIA_RECEIVER_APPLICATION_ID;
+        }
+    }
+
     public static boolean castAvailable() {
-        if (EnvironmentVariables.CAST_APPLICATION_ID == null) {
-            Log.w(TAG, "CAST_APPLICATION_ID not provided");
-            return false;
+        if (castApplicationId() == DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)  {
+            Log.i(TAG, "Using DEFAULT_MEDIA_RECEIVER_APPLICATION_ID for casting");
         }
         try {
             Class.forName("com.google.android.gms.cast.CastDevice");
@@ -56,6 +64,6 @@ public final class GoogleCompat {
     }
 
     public static String getCastControlCategory() {
-        return CastMediaControlIntent.categoryForCast(EnvironmentVariables.CAST_APPLICATION_ID);
+        return CastMediaControlIntent.categoryForCast(castApplicationId());
     }
 }


### PR DESCRIPTION
This enables people who haven't registered with Google to use casting when building the app for themselves.