### PR TITLE
Replace jetty ArrayQueue with java ArrayQueue

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/util/DownloadFileItemHelperCallback.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/DownloadFileItemHelperCallback.java
@@ -4,9 +4,9 @@ import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
 import android.util.Log;
 
-import org.eclipse.jetty.util.ArrayQueue;
 
 import java.util.Queue;
+import java.util.ArrayDeque;
 
 import github.daneren2005.dsub.adapter.SectionAdapter;
 import github.daneren2005.dsub.fragments.SubsonicFragment;
@@ -22,7 +22,7 @@ public class DownloadFileItemHelperCallback extends ItemTouchHelper.SimpleCallba
 	private boolean mainList;
 
 	private BackgroundTask pendingTask = null;
-	private Queue pendingOperations = new ArrayQueue();
+	private Queue pendingOperations = new ArrayDeque();
 
 	public DownloadFileItemHelperCallback(SubsonicFragment fragment, boolean mainList) {
 		super(ItemTouchHelper.UP | ItemTouchHelper.DOWN, ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT);


### PR DESCRIPTION
While jetty's `ArrayQueue` is still present in the version currently used by DSub, it's been removed upstream for a while and been replaced with Java's builtin one https://github.com/eclipse/jetty.project/issues/751
