### PR TITLE
Show mediastyle notification on secure lockscreen

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Notifications.java
@@ -99,6 +99,7 @@ public final class Notifications {
 				.setSmallIcon(R.drawable.stat_notify_playing)
 				.setContentTitle(title)
 				.setContentText(artist + " - " + album)
+				.setVisibility(Notification.VISIBILITY_PUBLIC)
 				.setStyle(mediaStyle);
 
 			// Set the album art.


### PR DESCRIPTION
Allow mediastyle playback notification to show up properly on lockscreens that hide sensitive notifications. For DSub's non-mediastyle implementation, this is already done on line 162. No need to check for LOLLIPOP+ because usingMediaStyleNotification already requires LOLLIPOP+.