### PR TITLE
Fix for missing extras Bundle and play all for first level subdirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ proguard_logs/
 local.properties
 *Thumbs.db
 app/google/release
+.keystore

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,4 +78,6 @@ dependencies {
 	implementation group: 'org.eclipse.jetty', name: 'jetty-server', version:'8.1.16.v20140903'
 	implementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version:'8.1.16.v20140903'
 	implementation group: 'org.eclipse.jetty', name: 'jetty-client', version:'8.1.16.v20140903'
+	implementation 'com.jakewharton:disklrucache:2.0.2'
+	implementation 'commons-io:commons-io:2.6'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,8 @@
 
     <supports-screens android:anyDensity="true" android:xlargeScreens="true" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
 
-    <application android:label="@string/common.appname"
+    <application android:name=".DSub"
+		android:label="@string/common.appname"
     	android:backupAgent="github.daneren2005.dsub.util.SettingsBackupAgent"
     	android:icon="@drawable/launch"
     	android:theme="@style/Theme.DSub.Light"

--- a/app/src/main/java/cz/fhucho/android/util/SimpleDiskCache.java
+++ b/app/src/main/java/cz/fhucho/android/util/SimpleDiskCache.java
@@ -1,0 +1,333 @@
+package cz.fhucho.android.util;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+import com.jakewharton.disklrucache.DiskLruCache;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adapted from https://github.com/fhucho/simple-disk-cache
+ * License Apache 2.0
+ */
+@SuppressWarnings("all")
+public class SimpleDiskCache {
+
+	private static final int VALUE_IDX = 0;
+	private static final int METADATA_IDX = 1;
+	private static final List<File> usedDirs = new ArrayList<File>();
+
+	private com.jakewharton.disklrucache.DiskLruCache diskLruCache;
+	private int mAppVersion;
+
+	private SimpleDiskCache(File dir, int appVersion, long maxSize) throws IOException {
+		mAppVersion = appVersion;
+		diskLruCache = DiskLruCache.open(dir, appVersion, 2, maxSize);
+	}
+
+	public static synchronized SimpleDiskCache open(File dir, int appVersion, long maxSize)
+			throws IOException {
+		if (usedDirs.contains(dir)) {
+			throw new IllegalStateException("Cache dir " + dir.getAbsolutePath() + " was used before.");
+		}
+
+		usedDirs.add(dir);
+
+		return new SimpleDiskCache(dir, appVersion, maxSize);
+	}
+
+	/**
+	 * User should be sure there are no outstanding operations.
+	 * @throws IOException
+	 */
+	public void clear() throws IOException {
+		File dir = diskLruCache.getDirectory();
+		long maxSize = diskLruCache.getMaxSize();
+		diskLruCache.delete();
+		diskLruCache = DiskLruCache.open(dir, mAppVersion, 2, maxSize);
+	}
+
+	public DiskLruCache getCache() {
+		return diskLruCache;
+	}
+
+	public InputStreamEntry getInputStream(String key) throws IOException {
+		DiskLruCache.Snapshot snapshot = diskLruCache.get(toInternalKey(key));
+		if (snapshot == null) return null;
+		return new InputStreamEntry(snapshot, readMetadata(snapshot));
+	}
+
+	public BitmapEntry getBitmap(String key) throws IOException {
+		DiskLruCache.Snapshot snapshot = diskLruCache.get(toInternalKey(key));
+		if (snapshot == null) return null;
+
+		try {
+			Bitmap bitmap = BitmapFactory.decodeStream(snapshot.getInputStream(VALUE_IDX));
+			return new BitmapEntry(bitmap, readMetadata(snapshot));
+		} finally {
+			snapshot.close();
+		}
+	}
+
+	public StringEntry getString(String key) throws IOException {
+		DiskLruCache.Snapshot snapshot = diskLruCache.get(toInternalKey(key));
+		if (snapshot == null) return null;
+
+		try {
+			return new StringEntry(snapshot.getString(VALUE_IDX), readMetadata(snapshot));
+		} finally {
+			snapshot.close();
+		}
+	}
+
+	public boolean contains(String key) throws IOException {
+		DiskLruCache.Snapshot snapshot = diskLruCache.get(toInternalKey(key));
+		if(snapshot==null) return false;
+
+		snapshot.close();
+		return true;
+	}
+
+	public OutputStream openStream(String key) throws IOException {
+		return openStream(key, new HashMap<String, Serializable>());
+	}
+
+	public OutputStream openStream(String key, Map<String, ? extends Serializable> metadata)
+			throws IOException {
+		DiskLruCache.Editor editor = diskLruCache.edit(toInternalKey(key));
+		try {
+			writeMetadata(metadata, editor);
+			BufferedOutputStream bos = new BufferedOutputStream(editor.newOutputStream(VALUE_IDX));
+			return new CacheOutputStream(bos, editor);
+		} catch (IOException e) {
+			editor.abort();
+			throw e;
+		}
+	}
+
+	public void put(String key, InputStream is) throws IOException {
+		put(key, is, new HashMap<String, Serializable>());
+	}
+
+	public void put(String key, InputStream is, Map<String, Serializable> annotations)
+			throws IOException {
+		OutputStream os = null;
+		try {
+			os = openStream(key, annotations);
+			IOUtils.copy(is, os);
+		} finally {
+			if (os != null) os.close();
+		}
+	}
+
+	public void put(String key, String value) throws IOException {
+		put(key, value, new HashMap<String, Serializable>());
+	}
+
+	public void put(String key, String value, Map<String, ? extends Serializable> annotations)
+			throws IOException {
+		OutputStream cos = null;
+		try {
+			cos = openStream(key, annotations);
+			cos.write(value.getBytes());
+		} finally {
+			if (cos != null) cos.close();
+		}
+
+	}
+
+	private void writeMetadata(Map<String, ? extends Serializable> metadata,
+			DiskLruCache.Editor editor) throws IOException {
+		ObjectOutputStream oos = null;
+		try {
+			oos = new ObjectOutputStream(new BufferedOutputStream(
+					editor.newOutputStream(METADATA_IDX)));
+			oos.writeObject(metadata);
+		} finally {
+			IOUtils.closeQuietly(oos);
+		}
+	}
+
+	private Map<String, Serializable> readMetadata(DiskLruCache.Snapshot snapshot)
+			throws IOException {
+		ObjectInputStream ois = null;
+		try {
+			ois = new ObjectInputStream(new BufferedInputStream(
+					snapshot.getInputStream(METADATA_IDX)));
+			@SuppressWarnings("unchecked")
+			Map<String, Serializable> annotations = (Map<String, Serializable>) ois.readObject();
+			return annotations;
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		} finally {
+			IOUtils.closeQuietly(ois);
+		}
+	}
+
+	private String toInternalKey(String key) {
+		return md5(key);
+	}
+
+	private String md5(String s) {
+		try {
+			MessageDigest m = MessageDigest.getInstance("MD5");
+			m.update(s.getBytes("UTF-8"));
+			byte[] digest = m.digest();
+			BigInteger bigInt = new BigInteger(1, digest);
+			return bigInt.toString(16);
+		} catch (NoSuchAlgorithmException e) {
+			throw new AssertionError();
+		} catch (UnsupportedEncodingException e) {
+			throw new AssertionError();
+		}
+	}
+
+	private class CacheOutputStream extends FilterOutputStream {
+
+		private final DiskLruCache.Editor editor;
+		private boolean failed = false;
+
+		private CacheOutputStream(OutputStream os, DiskLruCache.Editor editor) {
+			super(os);
+			this.editor = editor;
+		}
+
+		@Override
+		public void close() throws IOException {
+			IOException closeException = null;
+			try {
+				super.close();
+			} catch (IOException e) {
+				closeException = e;
+			}
+
+			if (failed) {
+				editor.abort();
+			} else {
+				editor.commit();
+			}
+
+			if (closeException != null) throw closeException;
+		}
+
+		@Override
+		public void flush() throws IOException {
+			try {
+				super.flush();
+			} catch (IOException e) {
+				failed = true;
+				throw e;
+			}
+		}
+
+		@Override
+		public void write(int oneByte) throws IOException {
+			try {
+				super.write(oneByte);
+			} catch (IOException e) {
+				failed = true;
+				throw e;
+			}
+		}
+
+		@Override
+		public void write(byte[] buffer) throws IOException {
+			try {
+				super.write(buffer);
+			} catch (IOException e) {
+				failed = true;
+				throw e;
+			}
+		}
+
+		@Override
+		public void write(byte[] buffer, int offset, int length) throws IOException {
+			try {
+				super.write(buffer, offset, length);
+			} catch (IOException e) {
+				failed = true;
+				throw e;
+			}
+		}
+	}
+
+	public static class InputStreamEntry {
+		private final DiskLruCache.Snapshot snapshot;
+		private final Map<String, Serializable> metadata;
+
+		public InputStreamEntry(DiskLruCache.Snapshot snapshot, Map<String, Serializable> metadata) {
+			this.metadata = metadata;
+			this.snapshot = snapshot;
+		}
+
+		public InputStream getInputStream() {
+			return snapshot.getInputStream(VALUE_IDX);
+		}
+
+		public Map<String, Serializable> getMetadata() {
+			return metadata;
+		}
+
+		public void close() {
+			snapshot.close();
+
+		}
+
+	}
+
+	public static class BitmapEntry {
+		private final Bitmap bitmap;
+		private final Map<String, Serializable> metadata;
+
+		public BitmapEntry(Bitmap bitmap, Map<String, Serializable> metadata) {
+			this.bitmap = bitmap;
+			this.metadata = metadata;
+		}
+
+		public Bitmap getBitmap() {
+			return bitmap;
+		}
+
+		public Map<String, Serializable> getMetadata() {
+			return metadata;
+		}
+	}
+
+	public static class StringEntry {
+		private final String string;
+		private final Map<String, Serializable> metadata;
+
+		public StringEntry(String string, Map<String, Serializable> metadata) {
+			this.string = string;
+			this.metadata = metadata;
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public Map<String, Serializable> getMetadata() {
+			return metadata;
+		}
+	}
+}

--- a/app/src/main/java/github/daneren2005/dsub/DSub.java
+++ b/app/src/main/java/github/daneren2005/dsub/DSub.java
@@ -1,0 +1,26 @@
+package github.daneren2005.dsub;
+
+import android.app.Application;
+
+import java.io.IOException;
+
+import cz.fhucho.android.util.SimpleDiskCache;
+
+public class DSub extends Application {
+
+    private SimpleDiskCache cache;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        try {
+            cache = SimpleDiskCache.open(getExternalCacheDir(), 1, 64 * 1024 * 1024);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SimpleDiskCache getCache() {
+        return cache;
+    }
+}

--- a/app/src/main/java/github/daneren2005/dsub/domain/MusicDirectory.java
+++ b/app/src/main/java/github/daneren2005/dsub/domain/MusicDirectory.java
@@ -20,26 +20,25 @@ package github.daneren2005.dsub.domain;
 
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.media.MediaMetadataRetriever;
 import android.os.Build;
 import android.util.Log;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.text.Collator;
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.io.File;
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 
 import github.daneren2005.dsub.service.DownloadService;
@@ -263,6 +262,7 @@ public class MusicDirectory implements Serializable {
 		private int type = 0;
 		private int closeness;
 		private transient Artist linkedArtist;
+		private int albumPos = 0;
 
 		public Entry() {
 
@@ -601,6 +601,14 @@ public class MusicDirectory implements Serializable {
 			this.closeness = closeness;
 		}
 
+		public void setAlbumPos(int albumPos) {
+			this.albumPos = albumPos;
+		}
+
+		public int getAlbumPos() {
+			return albumPos;
+		}
+
 		public boolean isOnlineId(Context context) {
 			try {
 				String cacheLocation = Util.getPreferences(context).getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, null);
@@ -712,7 +720,16 @@ public class MusicDirectory implements Serializable {
 					return 1;
 				}
 			}
-			
+
+			int lhsAPos = lhs.getAlbumPos();
+			int rhsAPos = rhs.getAlbumPos();
+
+			if(lhsAPos < rhsAPos) {
+				return -1;
+			} else if(lhsAPos > rhsAPos) {
+				return 1;
+			}
+
 			Integer lhsTrack = lhs.getTrack();
 			Integer rhsTrack = rhs.getTrack();
 			if(lhsTrack != null && rhsTrack != null && lhsTrack != rhsTrack) {

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -30,49 +30,7 @@ import static github.daneren2005.dsub.domain.PlayerState.STARTED;
 import static github.daneren2005.dsub.domain.PlayerState.STOPPED;
 import static github.daneren2005.dsub.domain.RemoteControlState.LOCAL;
 
-import github.daneren2005.dsub.R;
-import github.daneren2005.dsub.activity.SubsonicActivity;
-import github.daneren2005.dsub.audiofx.AudioEffectsController;
-import github.daneren2005.dsub.audiofx.EqualizerController;
-import github.daneren2005.dsub.domain.Bookmark;
-import github.daneren2005.dsub.domain.InternetRadioStation;
-import github.daneren2005.dsub.domain.MusicDirectory;
-import github.daneren2005.dsub.domain.PlayerState;
-import github.daneren2005.dsub.domain.PodcastEpisode;
-import github.daneren2005.dsub.domain.RemoteControlState;
-import github.daneren2005.dsub.domain.RepeatMode;
-import github.daneren2005.dsub.domain.ServerInfo;
-import github.daneren2005.dsub.receiver.AudioNoisyReceiver;
-import github.daneren2005.dsub.receiver.MediaButtonIntentReceiver;
-import github.daneren2005.dsub.util.ArtistRadioBuffer;
-import github.daneren2005.dsub.util.ImageLoader;
-import github.daneren2005.dsub.util.Notifications;
-import github.daneren2005.dsub.util.SilentBackgroundTask;
-import github.daneren2005.dsub.util.Constants;
-import github.daneren2005.dsub.util.MediaRouteManager;
-import github.daneren2005.dsub.util.ShufflePlayBuffer;
-import github.daneren2005.dsub.util.SimpleServiceBinder;
-import github.daneren2005.dsub.util.UpdateHelper;
-import github.daneren2005.dsub.util.Util;
-import github.daneren2005.dsub.util.compat.RemoteControlClientBase;
-import github.daneren2005.dsub.util.tags.BastpUtil;
-import github.daneren2005.dsub.view.UpdateView;
-import github.daneren2005.serverproxy.BufferProxy;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.app.Service;
 import android.content.ComponentCallbacks2;
 import android.content.ComponentName;
@@ -90,11 +48,53 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.PowerManager;
+import android.support.v4.util.LruCache;
 import android.support.v7.media.MediaRouteSelector;
 import android.support.v7.media.MediaRouter;
 import android.util.Log;
-import android.support.v4.util.LruCache;
 import android.view.KeyEvent;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import github.daneren2005.dsub.DSub;
+import github.daneren2005.dsub.R;
+import github.daneren2005.dsub.activity.SubsonicActivity;
+import github.daneren2005.dsub.audiofx.AudioEffectsController;
+import github.daneren2005.dsub.audiofx.EqualizerController;
+import github.daneren2005.dsub.domain.Bookmark;
+import github.daneren2005.dsub.domain.InternetRadioStation;
+import github.daneren2005.dsub.domain.MusicDirectory;
+import github.daneren2005.dsub.domain.PlayerState;
+import github.daneren2005.dsub.domain.PodcastEpisode;
+import github.daneren2005.dsub.domain.RemoteControlState;
+import github.daneren2005.dsub.domain.RepeatMode;
+import github.daneren2005.dsub.domain.ServerInfo;
+import github.daneren2005.dsub.receiver.AudioNoisyReceiver;
+import github.daneren2005.dsub.receiver.MediaButtonIntentReceiver;
+import github.daneren2005.dsub.util.ArtistRadioBuffer;
+import github.daneren2005.dsub.util.Constants;
+import github.daneren2005.dsub.util.ImageLoader;
+import github.daneren2005.dsub.util.MediaRouteManager;
+import github.daneren2005.dsub.util.Notifications;
+import github.daneren2005.dsub.util.ShufflePlayBuffer;
+import github.daneren2005.dsub.util.SilentBackgroundTask;
+import github.daneren2005.dsub.util.SimpleServiceBinder;
+import github.daneren2005.dsub.util.UpdateHelper;
+import github.daneren2005.dsub.util.Util;
+import github.daneren2005.dsub.util.compat.RemoteControlClientBase;
+import github.daneren2005.dsub.util.tags.BastpUtil;
+import github.daneren2005.dsub.view.UpdateView;
+import github.daneren2005.serverproxy.BufferProxy;
 
 /**
  * @author Sindre Mehus
@@ -273,7 +273,7 @@ public class DownloadService extends Service {
 
 		if (mRemoteControl == null) {
 			// Use the remote control APIs (if available) to set the playback state
-			mRemoteControl = RemoteControlClientBase.createInstance();
+			mRemoteControl = RemoteControlClientBase.createInstance(((DSub)getApplication()).getCache());
 			ComponentName mediaButtonReceiverComponent = new ComponentName(getPackageName(), MediaButtonIntentReceiver.class.getName());
 			mRemoteControl.register(this, mediaButtonReceiverComponent);
 		}

--- a/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientBase.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientBase.java
@@ -1,30 +1,33 @@
 package github.daneren2005.dsub.util.compat;
 
-import github.daneren2005.dsub.domain.MusicDirectory;
-import github.daneren2005.dsub.service.DownloadFile;
-
 import android.content.ComponentName;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.support.v7.media.MediaRouter;
 import android.os.Build;
+import android.support.v7.media.MediaRouter;
 
 import java.util.List;
 
+import cz.fhucho.android.util.SimpleDiskCache;
+import github.daneren2005.dsub.domain.MusicDirectory;
+import github.daneren2005.dsub.service.DownloadFile;
+
 public abstract class RemoteControlClientBase {
-	
-	public static RemoteControlClientBase createInstance() {
+
+	protected final SimpleDiskCache cache;
+
+	public static RemoteControlClientBase createInstance(SimpleDiskCache cache) {
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-			return new RemoteControlClientLP();
+			return new RemoteControlClientLP(cache);
 		} else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-			return new RemoteControlClientJB();
+			return new RemoteControlClientJB(cache);
 		} else {
-			return new RemoteControlClientICS();
+			return new RemoteControlClientICS(cache);
 		}
 	}
 	
-	protected RemoteControlClientBase() {
-		// Avoid instantiation
+	protected RemoteControlClientBase(SimpleDiskCache cache) {
+		this.cache = cache;
 	}
 	
 	public abstract void register(final Context context, final ComponentName mediaButtonReceiverComponent);

--- a/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientICS.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientICS.java
@@ -1,9 +1,5 @@
 package github.daneren2005.dsub.util.compat;
 
-import github.daneren2005.dsub.domain.MusicDirectory;
-import github.daneren2005.dsub.service.DownloadFile;
-import github.daneren2005.dsub.service.DownloadService;
-import github.daneren2005.dsub.util.ImageLoader;
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
 import android.content.ComponentName;
@@ -17,7 +13,12 @@ import android.support.v7.media.MediaRouter;
 
 import java.util.List;
 
+import cz.fhucho.android.util.SimpleDiskCache;
 import github.daneren2005.dsub.activity.SubsonicActivity;
+import github.daneren2005.dsub.domain.MusicDirectory;
+import github.daneren2005.dsub.service.DownloadFile;
+import github.daneren2005.dsub.service.DownloadService;
+import github.daneren2005.dsub.util.ImageLoader;
 
 @TargetApi(14)
 public class RemoteControlClientICS extends RemoteControlClientBase {
@@ -26,7 +27,11 @@ public class RemoteControlClientICS extends RemoteControlClientBase {
 	protected RemoteControlClient mRemoteControl;
 	protected ImageLoader imageLoader;
 	protected DownloadService downloadService;
-	
+
+	public RemoteControlClientICS(SimpleDiskCache cache) {
+		super(cache);
+	}
+
 	public void register(final Context context, final ComponentName mediaButtonReceiverComponent) {
 		downloadService = (DownloadService) context;
 		AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);

--- a/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientJB.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/compat/RemoteControlClientJB.java
@@ -5,10 +5,16 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.media.RemoteControlClient;
 
+import cz.fhucho.android.util.SimpleDiskCache;
 import github.daneren2005.dsub.util.SilentBackgroundTask;
 
 @TargetApi(18)
 public class RemoteControlClientJB extends RemoteControlClientICS {
+
+	public RemoteControlClientJB(SimpleDiskCache cache) {
+		super(cache);
+	}
+
 	@Override
 	public void register(final Context context, final ComponentName mediaButtonReceiverComponent) {
 		super.register(context, mediaButtonReceiverComponent);


### PR DESCRIPTION
1. cache for extras as some car BT/media controller setups do not pass extras properly

2. supporting play-all of first level subdirs when not browsing by tags - useful if music library is organized by artists->albums->songs; keeping subdirs sorting via `albumPos`