### PR TITLE
Background playing - setting to ignore audio focus

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/util/Util.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Util.java
@@ -1342,21 +1342,27 @@ public final class Util {
     
     @TargetApi(8)
 	public static void requestAudioFocus(final Context context, final AudioManager audioManager) {
-    	if(Build.VERSION.SDK_INT >= 26) {
-    		if(audioFocusRequest == null) {
-				AudioAttributes playbackAttributes = new AudioAttributes.Builder()
-						.setUsage(AudioAttributes.USAGE_MEDIA)
-						.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-						.build();
+		SharedPreferences prefs = getPreferences(context);
+		int lossPref = Integer.parseInt(prefs.getString(Constants.PREFERENCES_KEY_TEMP_LOSS, "1"));
 
-				audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
-						.setAudioAttributes(playbackAttributes)
-						.setOnAudioFocusChangeListener(getAudioFocusChangeListener(context, audioManager))
-						.setWillPauseWhenDucked(true)
-						.build();
-				audioManager.requestAudioFocus(audioFocusRequest);
+		if(Build.VERSION.SDK_INT >= 26) {
+			// don't request audio focus if lossPref is 3 (don't use audiofocus)
+    		if(audioFocusRequest == null && lossPref != 3) {
+					AudioAttributes playbackAttributes = new AudioAttributes.Builder()
+							.setUsage(AudioAttributes.USAGE_MEDIA)
+							.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+							.build();
+
+					audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+							.setAudioAttributes(playbackAttributes)
+							.setOnAudioFocusChangeListener(getAudioFocusChangeListener(context, audioManager))
+							.setWillPauseWhenDucked(true)
+							.build();
+					audioManager.requestAudioFocus(audioFocusRequest);
+
+
 			}
-		} else if (Build.VERSION.SDK_INT >= 8 && focusListener == null) {
+		} else if (Build.VERSION.SDK_INT >= 8 && focusListener == null && lossPref != 3) {
     		audioManager.requestAudioFocus(focusListener = getAudioFocusChangeListener(context, audioManager), AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
     	}
     }
@@ -1365,10 +1371,10 @@ public final class Util {
 		return new OnAudioFocusChangeListener() {
 			public void onAudioFocusChange(int focusChange) {
 				DownloadService downloadService = (DownloadService)context;
+				SharedPreferences prefs = getPreferences(context);
 				if((focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT || focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) && !downloadService.isRemoteEnabled()) {
 					if(downloadService.getPlayerState() == PlayerState.STARTED) {
 						Log.i(TAG, "Temporary loss of focus");
-						SharedPreferences prefs = getPreferences(context);
 						int lossPref = Integer.parseInt(prefs.getString(Constants.PREFERENCES_KEY_TEMP_LOSS, "1"));
 						if(lossPref == 2 || (lossPref == 1 && focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)) {
 							lowerFocus = true;
@@ -1390,7 +1396,11 @@ public final class Util {
 				} else if(focusChange == AudioManager.AUDIOFOCUS_LOSS && !downloadService.isRemoteEnabled()) {
 					Log.i(TAG, "Permanently lost focus");
 					focusListener = null;
-					downloadService.pause();
+					int lossPref = Integer.parseInt(prefs.getString(Constants.PREFERENCES_KEY_TEMP_LOSS, "1"));
+					// if setting is "do nothing" - ignore audio focus switch because user wants background play
+					if (lossPref != 3) {
+						downloadService.pause();
+					}
 
 					if(audioFocusRequest != null && Build.VERSION.SDK_INT >= 26) {
 						audioManager.abandonAudioFocusRequest(audioFocusRequest);


### PR DESCRIPTION
App is wonderful, but I missed ability to play the music in background (like PowerAmp does - ignoring other apps)

I like to watch vlogs, podcasts and audiobooks with background music (thing such obvious in desktop machines) so I decided to modify the behaviour of setting "Temporary Loss of Focus". If user set to "Do Nothing" - all of other apps audio focus requests will be ignored and app will continue play. DSub will also stop requesting Audio Focus from other apps in this mode.

Additionally many smartphones allow to separate volume controls for different apps (Samsung and Motorola for sure) so this is very useful 