### PR TITLE
Fix album sort with duplicate track numbers

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/domain/MusicDirectory.java
+++ b/app/src/main/java/github/daneren2005/dsub/domain/MusicDirectory.java
@@ -717,11 +717,9 @@ public class MusicDirectory implements Serializable {
 			Integer rhsTrack = rhs.getTrack();
 			if(lhsTrack == rhsTrack) {
 				return collator.compare(lhs.getTitle(), rhs.getTitle());
-			}
-			if(lhsTrack != null && rhsTrack != null) {
+			} else if(lhsTrack != null && rhsTrack != null) {
 				return lhsTrack.compareTo(rhsTrack);
-			}
-			if(lhsTrack != null) {
+			} else if(lhsTrack != null) {
 				return -1;
 			}
 			return 1;

--- a/app/src/main/java/github/daneren2005/dsub/domain/MusicDirectory.java
+++ b/app/src/main/java/github/daneren2005/dsub/domain/MusicDirectory.java
@@ -715,15 +715,16 @@ public class MusicDirectory implements Serializable {
 			
 			Integer lhsTrack = lhs.getTrack();
 			Integer rhsTrack = rhs.getTrack();
-			if(lhsTrack != null && rhsTrack != null && lhsTrack != rhsTrack) {
-				return lhsTrack.compareTo(rhsTrack);
-			} else if(lhsTrack != null) {
-				return -1;
-			} else if(rhsTrack != null) {
-				return 1;
+			if(lhsTrack == rhsTrack) {
+				return collator.compare(lhs.getTitle(), rhs.getTitle());
 			}
-
-			return collator.compare(lhs.getTitle(), rhs.getTitle());
+			if(lhsTrack != null && rhsTrack != null) {
+				return lhsTrack.compareTo(rhsTrack);
+			}
+			if(lhsTrack != null) {
+				return -1;
+			}
+			return 1;
 		}
 		
 		public static void sort(List<Entry> entries) {


### PR DESCRIPTION
For some reason some of my folders contain duplicate track numbers. Some albums even have all track numbers set to `1`.
In this case, DSub reverses the sort order of these albums (a-z becomes z-a) so if the actual track numbers are at the start of the file name the album is actually reversed.

With this PR, we default to sorting by track name if the track numbers are not set or identical. In other cases, behavior remains unchanged.