### PR TITLE
Changed default account as the old one no longer exists

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/activity/SubsonicFragmentActivity.java
+++ b/app/src/main/java/github/daneren2005/dsub/activity/SubsonicFragmentActivity.java
@@ -740,7 +740,7 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 
 			editor.putString(Constants.PREFERENCES_KEY_SERVER_NAME + 1, "Demo Server");
 			editor.putString(Constants.PREFERENCES_KEY_SERVER_URL + 1, "http://demo.subsonic.org");
-			editor.putString(Constants.PREFERENCES_KEY_USERNAME + 1, "guest2");
+			editor.putString(Constants.PREFERENCES_KEY_USERNAME + 1, "guest");
 			if (Build.VERSION.SDK_INT < 23) {
 				editor.putString(Constants.PREFERENCES_KEY_PASSWORD + 1, "guest");
 			} else {


### PR DESCRIPTION
During testing of #1116 I noticed that the default account used in DSub no longer exists on the Subsonic demo server so I changed it to use guest instead of guest2 as this one is still there.