### PR TITLE
Fixed Sharing feature from returning incorrect URL

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/service/parser/ShareParser.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/parser/ShareParser.java
@@ -19,15 +19,12 @@
 package github.daneren2005.dsub.service.parser;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.util.Log;
 
 import github.daneren2005.dsub.R;
 import github.daneren2005.dsub.domain.ServerInfo;
 import github.daneren2005.dsub.domain.Share;
-import github.daneren2005.dsub.util.Constants;
 import github.daneren2005.dsub.util.ProgressListener;
-import github.daneren2005.dsub.util.Util;
 
 import org.xmlpull.v1.XmlPullParser;
 import java.io.Reader;
@@ -52,29 +49,22 @@ public class ShareParser extends MusicDirectoryEntryParser {
     public List<Share> parse(Reader reader, ProgressListener progressListener) throws Exception {
         init(reader);
 
-        List<Share> dir = new ArrayList<Share>();
+        List<Share> dir = new ArrayList<>();
         Share share = null;
         int eventType;
-
-		SharedPreferences prefs = Util.getPreferences(context);
-		String serverUrl = prefs.getString(Constants.PREFERENCES_KEY_SERVER_URL + instance, null);
-		if(serverUrl.charAt(serverUrl.length() - 1) != '/') {
-			serverUrl += '/';
-		}
-		serverUrl += "share/";
 
 		boolean isDateNormalized = ServerInfo.checkServerVersion(context, "1.11");
 		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ENGLISH);
 		if(isDateNormalized) {
 			dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 		}
-        
+
         do {
             eventType = nextParseEvent();
-            
+
             if (eventType == XmlPullParser.START_TAG) {
                 String name = getElementName();
-                
+
                 if ("share".equals(name)) {
                 	share = new Share();
 
@@ -85,11 +75,8 @@ public class ShareParser extends MusicDirectoryEntryParser {
 					}
 
 					String url = get("url");
-					if(url != null && url.indexOf(".php") == -1) {
-						url = url.replaceFirst(".*/([^/?]+).*", serverUrl + "$1");
-					}
-					share.setUrl(url);
 
+					share.setUrl(url);
                 	share.setDescription(get("description"));
 
 					try {


### PR DESCRIPTION
Remove any URL reformatting as Airsonic returns it properly. Should be tested with Subsonic.

Issue Reference: #978 

This check must have been in for a reason, therefore it may be possible that it breaks sharing on some Subsonic/Airsonic servers

In particular, this commit to libresonic (released v6.2.1) seems to have changed how share names were created:
https://github.com/airsonic/airsonic/commit/f7bd43136b6275de1206fd6be500f2961e0e6623
Subsonic introduced the Share feature in Subsonic REST API v1.6.0. Example:
http://www.subsonic.org/pages/inc/api/examples/shares_example_1.xml

That said, I am running this fine with Airsonic-Advanced 11.0.0-SNAPSHOT.20220625052932 and subsonic-rest-api v1.15.

Unfortunately, I do not have a Subsonic server up and running to test from and I could not find any identifying ways to determine if DSub is connected to an Subsonic or Airsonic server (methods I found reported ServerInfo.isStockSubsonic() to true), only what subsonic-rest-api I was dealing with (v1.15). I would love to know if Subsonic is returning the same long URL as it does in the 1.6.0 example or is returning the same values that we see here with Airsonic.

This might be something that needs to be looked into on the Airsonic server side if Subsonic is offering the short URL for shares. Either this code was warranted and people do not use the share function through DSub or one side (client/server) is providing inconsistent results. Any help with testing this would be very welcome.

I have uploaded a build to my fork for testing: https://github.com/mwielgosz/Subsonic/releases/tag/5.5.3-share-fix
This will require that you UNINSTALL your old DSub app as they are not signed with the same keystores.