### PR TITLE
Fix replaygain selection logic

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadService.java
@@ -2695,8 +2695,8 @@ public class DownloadService extends Service {
 				// Already false, no need to do anything here
 				
 				
-				// If playing a single album or no track gain, use album gain
-				if((singleAlbum || rg.album == 0) && rg.track != 0) {
+				// If playing a single album or no track gain, use album gain (if set)
+				if((singleAlbum || rg.track == 0) && rg.album != 0) {
 					adjust = rg.album;
 				} else {
 					// Otherwise, give priority to track gain


### PR DESCRIPTION
A non-zero album gain should be used when "singleAlbum" or no track gain is set. In all other cases the track gain should be used.

With the current logic, you could be stuck with a replaygain of 0 even if everything seems to be setup correctly:

```
singleAlbum = true / false
rg.album = 0.0
rg.track = -10.15
```

Because `rg.album == 0` was evaluated as `true`, we jumped into the `if`-path. This also happened when `singleAlbum = false` ("Use Track Gain" in the settings).

This fix changes the replaygain selection to match the provided comment:
```
singleAlbum = true;  rg.album set;   rg.track set     -> rg.album
singleAlbum = false; rg.album set;   rg.track set     -> rg.track
singleAlbum = true;  rg.album unset; rg.track set     -> rg.track
singleAlbum = false; rg.album unset; rg.track set     -> rg.track
singleAlbum = true;  rg.album set;   rg.track unset   -> rg.album
singleAlbum = false; rg.album set;   rg.track unset   -> rg.album
singleAlbum = true;  rg.album unset; rg.track unset   -> 0.0
singleAlbum = false; rg.album unset; rg.track unset   -> 0.0
```
