### PR TITLE
Fix multiselection behavior in playlist view

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/fragments/SelectDirectoryFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/SelectDirectoryFragment.java
@@ -849,7 +849,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 	@Override
 	protected void downloadBackground(final boolean save) {
 		List<Entry> songs = getSelectedEntries();
-		if(playlistId != null) {
+		if(songs.isEmpty() && playlistId != null) {
 			songs = entries;
 		}
 


### PR DESCRIPTION
Do not (permanently) cache all entries of a playlist when the user has made a selection. Only the selected songs are downloaded. When nothing is selected, it will still download the whole playlist.

All menu items on the playlist view should be aware of a selection made by the user. Currently, the "Cache" and "Permanent Cache" items will download the whole list even when there is a selection. This is because the list of songs to download is overwritten with all playlist entries in `downloadBackground()` when the app shows a playlist. My change will skip this if the user has selected songs which are returned by `getSelectedEntries()`.