### PR TITLE
Fix insecure connections

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/activity/SubsonicFragmentActivity.java
+++ b/app/src/main/java/github/daneren2005/dsub/activity/SubsonicFragmentActivity.java
@@ -739,13 +739,13 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 			editor.putBoolean(Constants.PREFERENCES_KEY_OFFLINE, false);
 
 			editor.putString(Constants.PREFERENCES_KEY_SERVER_NAME + 1, "Demo Server");
-			editor.putString(Constants.PREFERENCES_KEY_SERVER_URL + 1, "http://demo.subsonic.org");
-			editor.putString(Constants.PREFERENCES_KEY_USERNAME + 1, "guest");
+			editor.putString(Constants.PREFERENCES_KEY_SERVER_URL + 1, "https://demo.navidrome.org");
+			editor.putString(Constants.PREFERENCES_KEY_USERNAME + 1, "demo");
 			if (Build.VERSION.SDK_INT < 23) {
-				editor.putString(Constants.PREFERENCES_KEY_PASSWORD + 1, "guest");
+				editor.putString(Constants.PREFERENCES_KEY_PASSWORD + 1, "demo");
 			} else {
 				// Attempt to encrypt password
-				String encryptedDefaultPassword = KeyStoreUtil.encrypt("guest");
+				String encryptedDefaultPassword = KeyStoreUtil.encrypt("demo");
 
 				if (encryptedDefaultPassword != null) {
 					// If encryption succeeds, store encrypted password and flag password as encrypted
@@ -753,7 +753,7 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 					editor.putBoolean(Constants.PREFERENCES_KEY_ENCRYPTED_PASSWORD + 1, true);
 				} else {
 					// Fall back to plaintext if Keystore is having issue
-					editor = editor.putString(Constants.PREFERENCES_KEY_PASSWORD + 1, "guest");
+					editor = editor.putString(Constants.PREFERENCES_KEY_PASSWORD + 1, "demo");
 					editor.putBoolean(Constants.PREFERENCES_KEY_ENCRYPTED_PASSWORD + 1, false);
 				}
 			}

--- a/app/src/main/java/github/daneren2005/dsub/fragments/SettingsFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/SettingsFragment.java
@@ -585,6 +585,12 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 		serverAuthHeaderPreference.setSummary(R.string.settings_server_authheaders_summary);
 		serverAuthHeaderPreference.setTitle(R.string.settings_server_authheaders);
 
+		final CheckBoxPreference serverAllowInsecurePreference = new CheckBoxPreference(context);
+		serverAllowInsecurePreference.setKey(Constants.PREFERENCES_KEY_SERVER_ALLOW_INSECURE + instance);
+		serverAllowInsecurePreference.setChecked(Util.isAllowInsecureEnabled(context, instance));
+		serverAllowInsecurePreference.setSummary(R.string.settings_server_allowinsecure_summary);
+		serverAllowInsecurePreference.setTitle(R.string.settings_server_allowinsecure);
+
 		final Preference serverOpenBrowser = new Preference(context);
 		serverOpenBrowser.setKey(Constants.PREFERENCES_KEY_OPEN_BROWSER);
 		serverOpenBrowser.setPersistent(false);
@@ -660,6 +666,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 		screen.addPreference(serverTagPreference);
 		screen.addPreference(serverSyncPreference);
 		screen.addPreference(serverAuthHeaderPreference);
+		screen.addPreference(serverAllowInsecurePreference);
 		screen.addPreference(serverTestConnectionPreference);
 		screen.addPreference(serverOpenBrowser);
 		screen.addPreference(serverRemoveServerPreference);

--- a/app/src/main/java/github/daneren2005/dsub/service/RemoteController.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/RemoteController.java
@@ -39,11 +39,13 @@ public abstract class RemoteController {
 	protected boolean nextSupported = false;
 	protected ServerProxy proxy;
 	protected String rootLocation = "";
+	protected final boolean allowInsecure;
 
 	public RemoteController(DownloadService downloadService) {
 		this.downloadService = downloadService;
 		SharedPreferences prefs = Util.getPreferences(downloadService);
 		rootLocation = prefs.getString(Constants.PREFERENCES_KEY_CACHE_LOCATION, null);
+		allowInsecure = Util.isAllowInsecureEnabled(downloadService, Util.getActiveServer(downloadService));
 	}
 
 	public abstract void create(boolean playing, int seconds);
@@ -116,9 +118,10 @@ public abstract class RemoteController {
 
 	protected WebProxy createWebProxy() {
 		MusicService musicService = MusicServiceFactory.getMusicService(downloadService);
-		if(musicService instanceof CachedMusicService) {
+		// if we allow insecure connections, create WebProxy() with insecure ssl context
+		if(allowInsecure && (musicService instanceof CachedMusicService)) {
 			RESTMusicService restMusicService = ((CachedMusicService)musicService).getMusicService();
-			return new WebProxy(downloadService, restMusicService.getSSLSocketFactory(), restMusicService.getHostNameVerifier());
+			return new WebProxy(downloadService, restMusicService.getInsecureSSLSocketFactory(), restMusicService.getInsecureHostNameVerifier());
 		} else {
 			return new WebProxy(downloadService);
 		}

--- a/app/src/main/java/github/daneren2005/dsub/util/BackgroundTask.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/BackgroundTask.java
@@ -36,6 +36,9 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+
+import javax.net.ssl.SSLException;
+
 import github.daneren2005.dsub.R;
 import github.daneren2005.dsub.view.ErrorDialog;
 
@@ -129,6 +132,10 @@ public abstract class BackgroundTask<T> implements ProgressListener {
 
         if (error instanceof FileNotFoundException) {
             return context.getResources().getString(R.string.background_task_not_found);
+        }
+
+        if (error instanceof SSLException) {
+            return context.getResources().getString(R.string.background_task_network_insecure_error);
         }
 
         if (error instanceof IOException) {

--- a/app/src/main/java/github/daneren2005/dsub/util/Constants.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Constants.java
@@ -89,6 +89,7 @@ public final class Constants {
     public static final String PREFERENCES_KEY_PASSWORD = "password";
 	public static final String PREFERENCES_KEY_SERVER_AUTHHEADER = "authHeader";
     public static final String PREFERENCES_KEY_ENCRYPTED_PASSWORD = "encryptedPassword";
+    public static final String PREFERENCES_KEY_SERVER_ALLOW_INSECURE = "allowInsecure";
     public static final String PREFERENCES_KEY_INSTALL_TIME = "installTime";
     public static final String PREFERENCES_KEY_THEME = "theme";
     public static final String PREFERENCES_KEY_FULL_SCREEN = "fullScreen";

--- a/app/src/main/java/github/daneren2005/dsub/util/Util.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Util.java
@@ -470,6 +470,11 @@ public final class Util {
 		return prefs.getBoolean(Constants.PREFERENCES_KEY_SERVER_AUTHHEADER + instance, true);
 	}
 
+	public static boolean isAllowInsecureEnabled(Context context, int instance) {
+		SharedPreferences prefs = getPreferences(context);
+		return prefs.getBoolean(Constants.PREFERENCES_KEY_SERVER_ALLOW_INSECURE + instance, false);
+	}
+
 	public static String getParentFromEntry(Context context, MusicDirectory.Entry entry) {
 		if(Util.isTagBrowsing(context)) {
 			if(!entry.isDirectory()) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -649,5 +649,8 @@
 	<string name="menu.similar_artists.missing">Fehlende Künstler</string>
 	<string name="settings.casting_stream_original">Original streamen</string>
 	<string name="settings.casting_stream_original_summary">Zum streamen möglichst das Originalformat verwenden.</string>
+	<string name="settings.server_allowinsecure">Erlaube unsichere Verbindungen</string>
+	<string name="settings.server_allowinsecure_summary">Erlaube HTTP-Verbindungen und ignoriere Warnungen und Fehler bei HTTPS-Verbindungen (nicht empfohlen!)</string>
+	<string name="background_task.network_insecure_error">Die Verbindung zum Server ist unsicher. Unsichere Verbindungen sind in den Einstellungen nicht erlaubt worden.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -690,5 +690,8 @@
         <item quantity="one">One day left of trial period</item>
         <item quantity="other">%d days left of trial period</item>
     </plurals>
+	<string name="settings.server_allowinsecure">Allow insecure connections</string>
+	<string name="settings.server_allowinsecure_summary">Allow http traffic and ignore warnings and errors with https connections (not recommended!)</string>
+	<string name="background_task.network_insecure_error">The connection to the server is insecure. Insecure connections have not been enabled in the settings.</string>
 
 </resources>


### PR DESCRIPTION
Every server configuration has its own setting that enables the use of
insecure connections. This is disabled by default. Only verified https
connections are allowed. Error messages with a note about the setting
have been added.

CVE-2018-1000664

Discussed in #60

The second commit replaces the http-only subsonic.org demo server with the [Navidrome demo server](https://www.navidrome.org/demo/).